### PR TITLE
Feature: thread sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,7 @@ SLACK_BOT_TOKEN=xoxb-your-bot-token-here
 # Needs connections:write scope, starts with xapp-
 SLACK_APP_TOKEN=xapp-your-app-token-here
 
-# Enable thread-level context/session isolation (default: true)
-# THREAD_ISOLATION=true
+# Slack thread-level context/session isolation is always enabled in this fork
 
 # ===================
 # Mattermost Connector
@@ -58,7 +57,7 @@ MATTERMOST_TOKEN=your_bot_access_token
 # TRIGGER=!oc
 
 # Session retention period in minutes (default: 30)
-# Stale in-memory sessions are expired during event handling
+# Stale in-memory sessions are expired by a background sweep
 # SESSION_RETENTION_MINS=30
 
 # Session retention basis:

--- a/README.md
+++ b/README.md
@@ -314,7 +314,8 @@ This fork adds **per-Slack-thread session isolation** to `connectors/slack.ts`.
    - Verify only that thread is reset; other thread remains intact
 5. Restart verification
    - Restart connector
-   - Verify each thread context still maps independently
+   - Verify thread-scoped sessions start fresh after restart
+   - Verify a new mention/trigger recreates the thread session for later implicit follow-ups
 6. Retention timeout behavior
    - Set `SESSION_RETENTION_MINS=1` temporarily, restart service
    - Start a thread and wait >1 minute without activity
@@ -323,10 +324,12 @@ This fork adds **per-Slack-thread session isolation** to `connectors/slack.ts`.
 
 ### Edge cases & troubleshooting
 
-- Missing `team_id`, `channel`, or `ts` now fails fast with explicit log message.
+- Missing `channel` or `ts` fails fast with explicit log message.
+- Missing `team_id` is tolerated; the connector falls back to channel-based session normalization.
 - If `thread_ts` is absent, connector uses `event.ts` as thread root.
 - DMs and MPIMs use same thread isolation logic (channel ID remains part of context ID).
 - Session expiry runs on a background sweep and is based on `lastActivity` (user inactivity).
+- Startup cleanup of old on-disk session dirs is still based on directory age, not reconstructed Slack inactivity.
 - Never hardcode secrets; use environment variables or systemd environment settings.
 
 ### Staying in sync with upstream
@@ -335,6 +338,6 @@ This fork adds **per-Slack-thread session isolation** to `connectors/slack.ts`.
 git remote add upstream https://github.com/ominiverdi/opencode-chat-bridge.git
 git fetch upstream
 git rebase upstream/main
-# resolve any conflicts in connectors/slack.ts (the only modified file)
+# resolve any conflicts in connectors/slack.ts, README.md, .env.example, and Slack tests
 git push --force-with-lease origin main
 ```

--- a/connectors/slack.ts
+++ b/connectors/slack.ts
@@ -23,7 +23,7 @@
 import fs from "fs"
 import path from "path"
 import { App } from "@slack/bolt"
-import { ACPClient, type ActivityEvent } from "../src"
+import { ACPClient, type ActivityEvent, type OpenCodeCommand } from "../src"
 import {
   BaseConnector,
   type BaseSession,
@@ -159,6 +159,11 @@ export function shouldHandleThreadMessage(input: {
   return true
 }
 
+function isLocalBridgeCommand(command: string): boolean {
+  const cmd = command.toLowerCase().trim()
+  return cmd === "/status" || cmd === "/clear" || cmd === "/reset" || cmd === "/help"
+}
+
 // =============================================================================
 // Session Type
 // =============================================================================
@@ -275,8 +280,21 @@ export class SlackConnector extends BaseConnector<ChannelSession> {
       const query = match[1].trim()
 
       if (query.startsWith("/")) {
+        const existingSession = this.sessionManager.get(context.contextId)
+        const openCodeCommands: OpenCodeCommand[] = existingSession?.client.availableCommands || []
+
+        if (!isLocalBridgeCommand(query) && openCodeCommands.length === 0) {
+          await this.processQuery(context, query, client)
+          return
+        }
+
         await this.handleCommand(context.contextId, query, async (text) => {
           await postThreadReply(client, context.channelId, context.replyThreadTs, text)
+        }, {
+          openCodeCommands,
+          forwardToOpenCode: async (command) => {
+            await this.processQuery(context, command, client)
+          },
         })
         return
       }
@@ -419,30 +437,27 @@ export class SlackConnector extends BaseConnector<ChannelSession> {
 
   private async processQuery(context: SlackEventContext, query: string, slackClient: any): Promise<void> {
     const startTime = Date.now()
-
-    const session = await this.getOrCreateSession(context.contextId, (client) => ({
-      ...this.createBaseSession(client),
-    }))
-
-    if (!session) {
-      await postThreadReply(slackClient, context.channelId, context.replyThreadTs,
-        "Sorry, I couldn't connect to the AI service.")
+    if (this.activeQueries.has(context.contextId)) {
+      await postThreadReply(
+        slackClient,
+        context.channelId,
+        context.replyThreadTs,
+        "A request is already running in this thread. Please wait for it to finish."
+      )
       return
     }
 
-    session.messageCount++
-    session.lastActivity = new Date()
-    session.inputChars += query.length
     this.activeQueries.add(context.contextId)
 
-    const client = session.client
+    let session: ChannelSession | null = null
+    let client: ACPClient | null = null
     let responseBuffer = ""
     let toolResultsBuffer = ""
     let lastActivityMessage = ""
     let toolCallCount = 0
 
     const activityHandler = async (activity: ActivityEvent) => {
-      if (activity.type === "tool_start") {
+      if (activity.type === "tool_start" && session) {
         toolCallCount++
         if (activity.message !== lastActivityMessage) {
           lastActivityMessage = activity.message
@@ -458,11 +473,26 @@ export class SlackConnector extends BaseConnector<ChannelSession> {
       }
     }
 
-    client.on("activity", activityHandler)
-    client.on("chunk", chunkHandler)
-    client.on("update", updateHandler)
-
     try {
+      session = await this.getOrCreateSession(context.contextId, (client) => ({
+        ...this.createBaseSession(client),
+      }))
+
+      if (!session) {
+        await postThreadReply(slackClient, context.channelId, context.replyThreadTs,
+          "Sorry, I couldn't connect to the AI service.")
+        return
+      }
+
+      session.messageCount++
+      session.lastActivity = new Date()
+      session.inputChars += query.length
+
+      client = session.client
+      client.on("activity", activityHandler)
+      client.on("chunk", chunkHandler)
+      client.on("update", updateHandler)
+
       await client.prompt(query)
 
       const toolPaths = extractImagePaths(toolResultsBuffer)
@@ -496,11 +526,11 @@ export class SlackConnector extends BaseConnector<ChannelSession> {
       await postThreadReply(slackClient, context.channelId, context.replyThreadTs,
         "Sorry, something went wrong processing your request.")
     } finally {
-      client.off("activity", activityHandler)
-      client.off("chunk", chunkHandler)
-      client.off("update", updateHandler)
+      client?.off("activity", activityHandler)
+      client?.off("chunk", chunkHandler)
+      client?.off("update", updateHandler)
       // Reset inactivity clock from moment of delivery, not start of query.
-      session.lastActivity = new Date()
+      if (session) session.lastActivity = new Date()
       this.activeQueries.delete(context.contextId)
     }
   }

--- a/tests/integration/slack-event-mapping.test.ts
+++ b/tests/integration/slack-event-mapping.test.ts
@@ -13,7 +13,7 @@ describe("slack event mapping integration", () => {
 
     const payload = buildThreadReplyPayload(context.channelId, context.replyThreadTs, "ack")
     expect(payload.thread_ts).toBe("1711111111.001")
-    expect(context.contextId).toBe("TAPP:CCHAN:1711111111.001")
+    expect(context.contextId).toBe("CCHAN:1711111111.001")
   })
 
   test("thread reply maps to existing parent thread_ts", () => {
@@ -28,7 +28,7 @@ describe("slack event mapping integration", () => {
 
     const payload = buildThreadReplyPayload(context.channelId, context.replyThreadTs, "ack")
     expect(payload.thread_ts).toBe("1711111111.100")
-    expect(context.contextId).toBe("TAPP:CCHAN:1711111111.100")
+    expect(context.contextId).toBe("CCHAN:1711111111.100")
   })
 
   test("postThreadReply always sends thread_ts", async () => {

--- a/tests/unit/slack-thread-context.test.ts
+++ b/tests/unit/slack-thread-context.test.ts
@@ -174,4 +174,12 @@ describe("slack thread context keying", () => {
     })).toBe(true)
   })
 
+  test("trigger matching is case-insensitive for implicit thread filtering", () => {
+    expect(shouldHandleThreadMessage({
+      text: "!SQL query",
+      threadTs: "1710000000.123",
+      trigger: "!sql",
+    })).toBe(false)
+  })
+
 })


### PR DESCRIPTION
PR achieves
- Per-Slack-thread session isolation using channel:thread_root_ts
- Replies always posted into Slack threads via thread_ts
- Top-level mentions start threaded replies
- In-thread follow-ups can continue without re-mentioning the bot
- Minute-based session retention via SESSION_RETENTION_MINS
- Background expiry of stale in-memory sessions
- On-disk session cache cleanup on expiry
- Duplicate event suppression via dedupe keys
- README / env updates for Slack thread behavior
- New unit + integration coverage for thread context/reply mapping