### PR TITLE
feat: Matrix thread isolation via m.thread relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Thread isolation (Slack + Mattermost)** - Sessions are now keyed per thread (`channel:threadTs`)
+- **Thread isolation (Slack, Mattermost, Matrix)** - Sessions are now keyed per thread (`channel:threadTs`)
   instead of per channel. Each Slack thread gets its own isolated OpenCode session.
   Replies always stay in threads. Implicit follow-ups work without re-mentioning
   the bot. Configurable via `threadIsolation` in chat-bridge.json (default: true).

--- a/connectors/matrix-thread-helpers.ts
+++ b/connectors/matrix-thread-helpers.ts
@@ -1,0 +1,123 @@
+/**
+ * Matrix thread context helpers (pure functions, no SDK dependency)
+ *
+ * Extracted so tests can import them without needing matrix-bot-sdk installed.
+ */
+
+/**
+ * Normalized context extracted from a Matrix room event.
+ */
+export interface MatrixEventContext {
+  roomId: string
+  sender: string
+  text: string
+  eventId: string
+  /** Non-empty when this event is inside a m.thread relation */
+  threadRootEventId: string
+  /** The event ID to use as the thread root when replying */
+  replyThreadRootId: string
+  /** Session key: room:threadRootEventId (thread isolation) or room (per-room) */
+  sessionId: string
+  /** Idempotency key */
+  dedupeId: string
+}
+
+/**
+ * Extract the m.thread root event ID from event content, if present.
+ * Returns empty string for non-threaded events.
+ */
+export function extractThreadRootId(event: any): string {
+  const relatesTo = event?.content?.["m.relates_to"]
+  if (relatesTo?.rel_type === "m.thread" && relatesTo?.event_id) {
+    return relatesTo.event_id
+  }
+  return ""
+}
+
+/**
+ * Resolve the thread root event ID.
+ * If the event is in a thread, use the thread root. Otherwise use the event itself.
+ */
+export function resolveThreadRoot(threadRootEventId: string, eventId: string): string {
+  return threadRootEventId || eventId
+}
+
+/**
+ * Build the session key.
+ * When threadIsolation is true: room:threadRootEventId (per-thread)
+ * When false: room (per-room, old behavior)
+ */
+export function buildMatrixSessionId(
+  roomId: string,
+  replyThreadRootId: string,
+  threadIsolation: boolean
+): string {
+  if (threadIsolation) {
+    return `${roomId}:${replyThreadRootId}`
+  }
+  return roomId
+}
+
+/**
+ * Normalize raw Matrix event fields into a consistent MatrixEventContext.
+ */
+export function normalizeMatrixEventContext(
+  input: {
+    roomId: string
+    sender?: string
+    text?: string
+    eventId: string
+    threadRootEventId?: string
+  },
+  threadIsolation: boolean
+): MatrixEventContext {
+  const roomId = input.roomId
+  const eventId = input.eventId
+  const threadRootEventId = input.threadRootEventId || ""
+  const replyThreadRootId = resolveThreadRoot(threadRootEventId, eventId)
+
+  return {
+    roomId,
+    sender: input.sender || "unknown",
+    text: input.text || "",
+    eventId,
+    threadRootEventId,
+    replyThreadRootId,
+    sessionId: buildMatrixSessionId(roomId, replyThreadRootId, threadIsolation),
+    dedupeId: eventId,
+  }
+}
+
+/**
+ * Build the m.relates_to content for a thread reply.
+ * Includes m.in_reply_to fallback for clients that don't support threads.
+ */
+export function buildThreadRelation(threadRootEventId: string, lastEventId: string): object {
+  return {
+    rel_type: "m.thread",
+    event_id: threadRootEventId,
+    is_falling_back: true,
+    "m.in_reply_to": {
+      event_id: lastEventId,
+    },
+  }
+}
+
+/**
+ * Returns true if a plain thread reply (no trigger, no mention) should be
+ * considered for forwarding to the bot.
+ */
+export function shouldHandleThreadReply(input: {
+  text: string
+  threadRootEventId: string
+  trigger: string
+  botUserId: string
+}): boolean {
+  const text = input.text.trim()
+  if (!text) return false
+  if (!input.threadRootEventId) return false
+  if (text.toLowerCase().startsWith(`${input.trigger.toLowerCase()} `)) return false
+  if (text.toLowerCase().startsWith(`${input.trigger.toLowerCase()}`)) return false
+  if (text.includes(input.botUserId)) return false
+  return true
+}

--- a/connectors/matrix.ts
+++ b/connectors/matrix.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env bun
 /**
  * Matrix Connector for OpenCode Chat Bridge
- * 
+ *
  * Bridges Matrix rooms to OpenCode via ACP protocol.
  * Uses matrix-bot-sdk with native Rust crypto for E2EE support.
- * 
+ *
+ * Thread Isolation (configurable via chat-bridge.json matrix.threadIsolation):
+ *   When enabled, sessions are keyed on room:threadRootEventId so each
+ *   Matrix thread gets its own isolated OpenCode session. Plain replies
+ *   within a thread are forwarded automatically.
+ *
  * Usage:
  *   bun connectors/matrix.ts
- * 
+ *
  * Environment variables (see .env.example):
  *   MATRIX_HOMESERVER - Matrix server URL (e.g., https://matrix.org)
  *   MATRIX_ACCESS_TOKEN - Bot access token (or use PASSWORD for auto-login)
@@ -58,28 +63,52 @@ const BOT_NAME = config.botName
 const RATE_LIMIT_SECONDS = config.rateLimitSeconds
 const FORMAT_HTML = config.matrix.formatHtml || false
 const SESSION_RETENTION_DAYS = parseInt(process.env.SESSION_RETENTION_DAYS || "7", 10)
+const THREAD_ISOLATION = config.matrix.threadIsolation
 
 // Storage paths
-const STORAGE_PATH = process.env.MATRIX_STORAGE_PATH || 
+const STORAGE_PATH = process.env.MATRIX_STORAGE_PATH ||
   path.join(os.homedir(), ".local", "share", "opencode-matrix-bot")
 const STATE_STORAGE_PATH = path.join(STORAGE_PATH, "bot-state.json")
 const CRYPTO_STORAGE_PATH = path.join(STORAGE_PATH, "crypto")
 const TOKEN_FILE_PATH = path.join(STORAGE_PATH, "access_token")
 
 // =============================================================================
+// Thread Context Helpers (imported from standalone file for testability)
+// =============================================================================
+
+export {
+  type MatrixEventContext,
+  extractThreadRootId,
+  resolveThreadRoot,
+  buildMatrixSessionId,
+  normalizeMatrixEventContext,
+  buildThreadRelation,
+  shouldHandleThreadReply,
+} from "./matrix-thread-helpers"
+import {
+  type MatrixEventContext,
+  extractThreadRootId,
+  normalizeMatrixEventContext,
+  buildThreadRelation,
+  shouldHandleThreadReply,
+} from "./matrix-thread-helpers"
+
+// =============================================================================
 // Session Type
 // =============================================================================
 
 interface RoomSession extends BaseSession {
-  // Matrix-specific fields can be added here if needed
+  /** Track the last event ID sent in each thread for m.in_reply_to fallback */
+  lastEventIds: Map<string, string>
 }
 
 // =============================================================================
 // Matrix Connector
 // =============================================================================
 
-class MatrixConnector extends BaseConnector<RoomSession> {
+export class MatrixConnector extends BaseConnector<RoomSession> {
   private matrix: MatrixClient | null = null
+  private threadIsolation: boolean
 
   constructor() {
     super({
@@ -89,14 +118,14 @@ class MatrixConnector extends BaseConnector<RoomSession> {
       rateLimitSeconds: RATE_LIMIT_SECONDS,
       sessionRetentionDays: SESSION_RETENTION_DAYS,
     })
+    this.threadIsolation = THREAD_ISOLATION
   }
 
   // ---------------------------------------------------------------------------
-  // Abstract method implementations
+  // Lifecycle
   // ---------------------------------------------------------------------------
 
   async start(): Promise<void> {
-    // Validate configuration
     if (!ACCESS_TOKEN && !PASSWORD) {
       console.error("Error: Either MATRIX_ACCESS_TOKEN or MATRIX_PASSWORD must be set")
       console.error("Password-based login will save the token for future use.")
@@ -109,50 +138,35 @@ class MatrixConnector extends BaseConnector<RoomSession> {
     console.log(`  Storage: ${STORAGE_PATH}`)
     console.log(`  E2EE: enabled (Rust crypto with SQLite)`)
     this.logStartup()
+    console.log(`  Thread isolation: ${this.threadIsolation ? "on (per-thread sessions)" : "off (per-room sessions)"}`)
     await this.cleanupSessions()
 
-    // Ensure storage directories exist
     fs.mkdirSync(STORAGE_PATH, { recursive: true })
     fs.mkdirSync(CRYPTO_STORAGE_PATH, { recursive: true })
 
-    // Get access token (from config, saved file, or password login)
     let accessToken = await this.getOrCreateAccessToken()
-
     if (!accessToken) {
       console.error("Error: Could not obtain access token")
       process.exit(1)
     }
 
-    // Set up logging (reduce noise)
     LogService.setLogger(new RichConsoleLogger())
     LogService.setLevel(LogLevel.INFO)
     LogService.muteModule("Metrics")
 
-    // Create storage providers
     const stateStorage = new SimpleFsStorageProvider(STATE_STORAGE_PATH)
     const cryptoStorage = new RustSdkCryptoStorageProvider(CRYPTO_STORAGE_PATH)
 
-    // Create the client with E2EE support
     this.matrix = new MatrixClient(HOMESERVER, accessToken, stateStorage, cryptoStorage)
-
-    // Auto-join rooms when invited
     AutojoinRoomsMixin.setupOnClient(this.matrix)
 
-    // Handle decryption failures
     this.matrix.on("room.failed_decryption", async (roomId: string, event: any, error: Error) => {
       this.log(`[CRYPTO] Failed to decrypt in ${roomId}: ${error.message}`)
     })
 
-    // Handle messages (already decrypted by the SDK)
     this.matrix.on("room.message", this.handleRoomMessage.bind(this))
-
-    // Start the client (this prepares crypto automatically)
     await this.matrix.start()
-    
-    // Note: "Unverified device" warning is cosmetic - E2EE still works
-    // Cross-signing requires User Interactive Auth which bots can't easily do
-    // To remove warning: verify bot's device manually from Element
-    
+
     this.startSessionExpiryLoop()
     this.log("Started! Listening for messages...")
   }
@@ -160,11 +174,7 @@ class MatrixConnector extends BaseConnector<RoomSession> {
   async stop(): Promise<void> {
     this.log("Stopping...")
     await this.disconnectAllSessions()
-
-    if (this.matrix) {
-      this.matrix.stop()
-    }
-
+    if (this.matrix) this.matrix.stop()
     this.log("Stopped.")
   }
 
@@ -186,18 +196,88 @@ class MatrixConnector extends BaseConnector<RoomSession> {
     }
   }
 
+  /**
+   * Send a reply, respecting threadIsolation config.
+   * When true: send as thread reply with m.relates_to.
+   * When false: send plain message to room.
+   * Returns the event ID of the sent message (for tracking lastEventId).
+   */
+  private async sendReply(context: MatrixEventContext, text: string): Promise<string | null> {
+    try {
+      if (this.threadIsolation) {
+        const session = this.sessionManager.get(context.sessionId)
+        const lastEventId = session?.lastEventIds.get(context.replyThreadRootId) || context.replyThreadRootId
+        const relation = buildThreadRelation(context.replyThreadRootId, lastEventId)
+
+        let content: any
+        if (FORMAT_HTML) {
+          const html = await marked.parse(text)
+          content = {
+            msgtype: "m.text",
+            body: text,
+            format: "org.matrix.custom.html",
+            formatted_body: html,
+            "m.relates_to": relation,
+          }
+        } else {
+          content = {
+            msgtype: "m.text",
+            body: text,
+            "m.relates_to": relation,
+          }
+        }
+
+        const eventId = await this.matrix!.sendMessage(context.roomId, content)
+        // Track for next m.in_reply_to
+        if (session && eventId) {
+          session.lastEventIds.set(context.replyThreadRootId, eventId)
+        }
+        return eventId
+      } else {
+        await this.sendMessage(context.roomId, text)
+        return null
+      }
+    } catch (err) {
+      this.logError(`Failed to send reply to ${context.roomId}:`, err)
+      return null
+    }
+  }
+
+  /**
+   * Send a notice (for tool activity), respecting thread isolation.
+   */
+  private async sendNoticeReply(context: MatrixEventContext, text: string): Promise<void> {
+    try {
+      if (this.threadIsolation) {
+        const session = this.sessionManager.get(context.sessionId)
+        const lastEventId = session?.lastEventIds.get(context.replyThreadRootId) || context.replyThreadRootId
+        const relation = buildThreadRelation(context.replyThreadRootId, lastEventId)
+
+        const eventId = await this.matrix!.sendMessage(context.roomId, {
+          msgtype: "m.notice",
+          body: text,
+          "m.relates_to": relation,
+        })
+        if (session && eventId) {
+          session.lastEventIds.set(context.replyThreadRootId, eventId)
+        }
+      } else {
+        await this.matrix!.sendNotice(context.roomId, text)
+      }
+    } catch (err) {
+      this.logError(`Failed to send notice to ${context.roomId}:`, err)
+    }
+  }
+
   // ---------------------------------------------------------------------------
-  // Matrix-specific: Authentication
+  // Authentication
   // ---------------------------------------------------------------------------
 
   private async getOrCreateAccessToken(): Promise<string | null> {
-    // 1. Check config/env first
     if (ACCESS_TOKEN) {
       this.log("Using access token from config/env")
       return ACCESS_TOKEN
     }
-
-    // 2. Check for saved token file
     if (fs.existsSync(TOKEN_FILE_PATH)) {
       const savedToken = fs.readFileSync(TOKEN_FILE_PATH, "utf-8").trim()
       if (savedToken) {
@@ -205,29 +285,21 @@ class MatrixConnector extends BaseConnector<RoomSession> {
         return savedToken
       }
     }
-
-    // 3. Login with password and save token
     if (PASSWORD) {
       return await this.loginWithPassword()
     }
-
     return null
   }
 
   private async loginWithPassword(): Promise<string | null> {
     this.log("Logging in with password...")
-
     try {
       const auth = new MatrixAuth(HOMESERVER)
       const username = USER_ID!.split(":")[0].replace("@", "")
-      
       const client = await auth.passwordLogin(username, PASSWORD!, "OpenCode Chat Bridge")
       const accessToken = client.accessToken
-
-      // Save token for future use
       fs.writeFileSync(TOKEN_FILE_PATH, accessToken)
       this.log(`Login successful! Token saved to ${TOKEN_FILE_PATH}`)
-
       return accessToken
     } catch (err: any) {
       this.logError("Password login failed:", err.message || err)
@@ -236,16 +308,14 @@ class MatrixConnector extends BaseConnector<RoomSession> {
   }
 
   // ---------------------------------------------------------------------------
-  // Matrix-specific: Event handling
+  // Event handling
   // ---------------------------------------------------------------------------
 
   private async handleRoomMessage(roomId: string, event: any): Promise<void> {
     const message = new MessageEvent(event)
 
-    // Ignore non-text messages
     if (message.messageType !== "m.text") return
 
-    // Ignore our own messages
     const myUserId = await this.matrix!.getUserId()
     if (message.sender === myUserId) return
 
@@ -255,13 +325,25 @@ class MatrixConnector extends BaseConnector<RoomSession> {
     // Deduplicate events (Matrix sync replays)
     if (this.isDuplicateEvent(event.event_id || `${roomId}:${Date.now()}`)) return
 
-    this.log(`[MSG] ${message.sender}: ${body}`)
+    const threadRootEventId = extractThreadRootId(event)
 
-    // Check if this is a DM (direct message) room
+    const context = normalizeMatrixEventContext({
+      roomId,
+      sender: message.sender,
+      text: body,
+      eventId: event.event_id,
+      threadRootEventId,
+    }, this.threadIsolation)
+
+    // Touch session activity
+    const existingSession = this.sessionManager.get(context.sessionId)
+    if (existingSession) existingSession.lastActivity = new Date()
+
+    // Check if this is a DM
     const members = await this.matrix!.getJoinedRoomMembers(roomId)
     const isDM = members.length === 2
 
-    // Check trigger
+    // Extract query
     let query = ""
     if (body.startsWith(TRIGGER + " ")) {
       query = body.slice(TRIGGER.length + 1).trim()
@@ -270,162 +352,141 @@ class MatrixConnector extends BaseConnector<RoomSession> {
     } else if (body.includes(myUserId)) {
       query = body.replace(myUserId, "").trim()
     } else if (body.match(/^@?bot[:\s]/i)) {
-      // Match "bot:" or "@bot:" at start
       query = body.replace(/^@?bot[:\s]*/i, "").trim()
     } else if (isDM) {
-      // In DM rooms, respond to all messages without trigger
       query = body
+    } else if (this.threadIsolation && shouldHandleThreadReply({
+      text: body,
+      threadRootEventId,
+      trigger: TRIGGER,
+      botUserId: myUserId,
+    }) && this.sessionManager.has(context.sessionId)) {
+      // Implicit thread follow-up
+      query = body
+      this.log(`[THREAD] ${message.sender} in ${context.sessionId}: ${body}`)
     } else {
       return
     }
 
-    // Clean up any remaining colons or @ from the query
     query = query.replace(/^[:\s]+/, "").trim()
     if (!query) return
+
+    this.log(`[MSG] ${message.sender} in ${context.sessionId}: ${body}`)
 
     // Handle commands
     if (query.startsWith("/")) {
       const cmdName = query.slice(1).split(" ")[0].toLowerCase()
-      
-      // Bridge-local commands - handle without session
       const bridgeCommands = ["status", "clear", "reset", "help"]
       if (bridgeCommands.includes(cmdName)) {
-        const existingSession = this.sessionManager.get(roomId)
         const openCodeCommands = existingSession?.client.availableCommands || []
-        await this.handleCommand(roomId, query, async (text) => {
-          await this.sendNotice(roomId, text)
+        await this.handleCommand(context.sessionId, query, async (text) => {
+          await this.sendNoticeReply(context, text)
         }, { openCodeCommands })
         return
       }
-      
-      // All other /commands -> forward to OpenCode (creates session if needed)
-      // This supports /init, /compact, /review, and custom commands
+
       this.log(`[CMD] Forwarding to OpenCode: ${query}`)
       if (!this.checkRateLimit(message.sender)) return
-      await this.processQuery(roomId, message.sender, query)
+      await this.processQuery(context, query)
       return
     }
 
-    // Rate limiting
     if (!this.checkRateLimit(message.sender)) return
-
-    this.log(`[QUERY] ${roomId}: ${query}`)
-    await this.processQuery(roomId, message.sender, query)
+    await this.processQuery(context, query)
   }
 
   // ---------------------------------------------------------------------------
-  // Matrix-specific: Query processing
+  // Query processing
   // ---------------------------------------------------------------------------
 
-  private async processQuery(roomId: string, sender: string, query: string): Promise<void> {
+  private async processQuery(context: MatrixEventContext, query: string): Promise<void> {
     const startTime = Date.now()
 
-    // Guard against concurrent queries on the same session
-    if (this.isQueryActive(roomId)) {
-      await this.sendMessage(roomId, "A request is already running. Please wait for it to finish.")
+    if (this.isQueryActive(context.sessionId)) {
+      await this.sendReply(context, "A request is already running. Please wait for it to finish.")
       return
     }
-    this.markQueryActive(roomId)
+    this.markQueryActive(context.sessionId)
 
-    // Get or create session
-    const session = await this.getOrCreateSession(roomId, (client) =>
+    const session = await this.getOrCreateSession(context.sessionId, (client) =>
       this.createSession(client)
     )
 
     if (!session) {
-      await this.sendMessage(roomId, "Sorry, I couldn't connect to the AI service.")
+      await this.sendReply(context, "Sorry, I couldn't connect to the AI service.")
       return
     }
 
-    // Update session stats
     session.messageCount++
     session.lastActivity = new Date()
     session.inputChars += query.length
+    // Track the incoming event for m.in_reply_to chain
+    session.lastEventIds.set(context.replyThreadRootId, context.eventId)
 
     const client = session.client
 
-    // Track response chunks
     let responseBuffer = ""
     let toolResultsBuffer = ""
     let lastActivityMessage = ""
     let toolCallCount = 0
-    
-    // Track what we've already sent to avoid duplication (by content hash)
     const sentToolOutputs = new Set<string>()
 
-    // Activity events - show what the AI is doing
     const activityHandler = async (activity: ActivityEvent) => {
       if (activity.type === "tool_start") {
         toolCallCount++
         if (activity.message !== lastActivityMessage) {
           lastActivityMessage = activity.message
-          await this.sendNotice(roomId, `> ${activity.message}`)
+          await this.sendNoticeReply(context, `> ${activity.message}`)
         }
       }
     }
 
-    // Collect text chunks
-    const chunkHandler = (text: string) => {
-      responseBuffer += text
-    }
+    const chunkHandler = (text: string) => { responseBuffer += text }
 
-    // Capture tool results for image markers AND stream outputs immediately
     const updateHandler = async (update: any) => {
       if (update.type === "tool_result" && update.toolResult) {
         toolResultsBuffer += update.toolResult
-        
-        // Only show results for tools in streamTools config
+
         const toolName = update.toolName || ""
         const streamTools = config.streamTools || ["bash"]
-        const shouldShow = streamTools.some(t => toolName.includes(t))
-        
+        const shouldShow = streamTools.some((t: string) => toolName.includes(t))
+
         if (!shouldShow) {
           this.log(`[RESULT] Skipping ${toolName} result (not in streamTools)`)
           return
         }
-        
-        // Truncate very long outputs
+
         const maxLen = 2000
-        const result = update.toolResult.length > maxLen 
+        const result = update.toolResult.length > maxLen
           ? update.toolResult.slice(0, maxLen) + "\n... (truncated)"
           : update.toolResult
-        
-        // Skip empty results
+
         const trimmed = result.trim()
-        if (!trimmed) {
-          this.log(`[RESULT] Skipping empty tool result`)
-          return
-        }
-        
-        // Use content hash to prevent ANY duplicate content
+        if (!trimmed) return
+
         const contentHash = trimmed.slice(0, 100)
-        if (sentToolOutputs.has(contentHash)) {
-          this.log(`[RESULT] Skipping duplicate content`)
-          return
-        }
-        
+        if (sentToolOutputs.has(contentHash)) return
+
         sentToolOutputs.add(contentHash)
         try {
-          await this.sendMessage(roomId, trimmed)
+          await this.sendReply(context, trimmed)
         } catch (err) {
           this.log(`[RESULT] Error sending: ${err}`)
         }
       }
-      
-      // Handle streaming partial output during tool execution
-      // Only stream for tools in config.streamTools (default: ["bash"])
+
       if (update.type === "tool_output_delta" && update.partialOutput) {
         const toolName = update.toolName || ""
         const streamTools = config.streamTools || ["bash"]
-        const shouldStream = streamTools.some(t => toolName.includes(t))
-        
+        const shouldStream = streamTools.some((t: string) => toolName.includes(t))
+
         if (shouldStream) {
           const output = update.partialOutput.trim()
           if (output) {
             const contentHash = output.slice(0, 100)
             if (!sentToolOutputs.has(contentHash)) {
               sentToolOutputs.add(contentHash)
-              await this.sendMessage(roomId, output)
+              await this.sendReply(context, output)
               this.log(`[STREAM] Sent ${toolName} output (${output.length} chars)`)
             }
           }
@@ -433,19 +494,16 @@ class MatrixConnector extends BaseConnector<RoomSession> {
       }
     }
 
-    // Handle images from tools (e.g., doclibrary page images)
     const imageHandler = async (image: ImageContent) => {
       this.log(`Received image: ${image.mimeType}`)
-      await this.sendImageFromBase64(roomId, image)
+      await this.sendImageFromBase64(context, image)
     }
 
-    // Handle permission rejections
     const permissionHandler = async (event: { permission: string; path: string | null; message: string }) => {
       this.log(`[PERMISSION] Rejected: ${event.permission}${event.path ? ` (${event.path})` : ""}`)
-      await this.sendNotice(roomId, `> ${event.message}`)
+      await this.sendNoticeReply(context, `> ${event.message}`)
     }
 
-    // Set up listeners
     client.on("activity", activityHandler)
     client.on("chunk", chunkHandler)
     client.on("update", updateHandler)
@@ -461,95 +519,95 @@ class MatrixConnector extends BaseConnector<RoomSession> {
       for (const imagePath of toolPaths) {
         if (fs.existsSync(imagePath)) {
           this.log(`Uploading image from tool result: ${imagePath}`)
-          await this.sendImageFromFile(roomId, imagePath)
+          await this.sendImageFromFile(context, imagePath)
           uploadedPaths.add(imagePath)
         }
       }
 
-      // Process images from response (model might echo paths)
       const responsePaths = extractImagePaths(responseBuffer)
       for (const imagePath of responsePaths) {
         if (uploadedPaths.has(imagePath)) continue
         if (fs.existsSync(imagePath)) {
           this.log(`Uploading image from response: ${imagePath}`)
-          await this.sendImageFromFile(roomId, imagePath)
+          await this.sendImageFromFile(context, imagePath)
         }
       }
 
-      // Clean response and send (tool outputs were already streamed)
       const cleanResponse = sanitizeServerPaths(removeImageMarkers(responseBuffer))
-      
       if (cleanResponse) {
-        // Check if the model's response is just repeating what we already sent
         const responsePreview = cleanResponse.slice(0, 100)
         const alreadySent = sentToolOutputs.has(responsePreview)
-        
+
         if (!alreadySent) {
           session.outputChars += cleanResponse.length
-          await this.sendMessage(roomId, cleanResponse)
+          await this.sendReply(context, cleanResponse)
         }
       }
-      // Log elapsed time
+
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
       const outChars = cleanResponse ? cleanResponse.length : 0
       const tools = toolCallCount > 0 ? `, ${toolCallCount} tool${toolCallCount > 1 ? "s" : ""}` : ""
-      this.log(`[DONE] ${elapsed}s (${outChars} chars${tools})`)
+      this.log(`[DONE] ${elapsed}s (${outChars} chars${tools}) [${context.sessionId}]`)
     } catch (err) {
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-      this.logError(`[FAIL] ${elapsed}s:`, err)
-      await this.sendMessage(roomId, "Sorry, something went wrong processing your request.")
+      this.logError(`[FAIL] ${elapsed}s [${context.sessionId}]:`, err)
+      await this.sendReply(context, "Sorry, something went wrong processing your request.")
     } finally {
       client.off("activity", activityHandler)
       client.off("chunk", chunkHandler)
       client.off("update", updateHandler)
       client.off("image", imageHandler)
       client.off("permission_rejected", permissionHandler)
-      this.markQueryDone(roomId)
+      if (session) session.lastActivity = new Date()
+      this.markQueryDone(context.sessionId)
     }
   }
 
   private createSession(client: ACPClient): RoomSession {
     return {
       ...this.createBaseSession(client),
+      lastEventIds: new Map(),
     }
   }
 
   // ---------------------------------------------------------------------------
-  // Matrix-specific: Message sending
+  // Image sending (thread-aware)
   // ---------------------------------------------------------------------------
 
-  private async sendNotice(roomId: string, text: string): Promise<void> {
+  private async sendImageFromBase64(context: MatrixEventContext, image: ImageContent): Promise<void> {
     try {
-      await this.matrix!.sendNotice(roomId, text)
-    } catch (err) {
-      this.logError(`Failed to send notice to ${roomId}:`, err)
-    }
-  }
-
-  private async sendImageFromBase64(roomId: string, image: ImageContent): Promise<void> {
-    try {
-      // Decode base64 and upload to Matrix
       const buffer = Buffer.from(image.data, "base64")
       const mxcUrl = await this.matrix!.uploadContent(buffer, image.mimeType, image.alt || "image.png")
 
-      await this.matrix!.sendMessage(roomId, {
+      const content: any = {
         msgtype: "m.image",
         body: image.alt || "Image",
         url: mxcUrl,
-        info: {
-          mimetype: image.mimeType,
-          size: buffer.length,
-        },
-      })
+        info: { mimetype: image.mimeType, size: buffer.length },
+      }
 
-      this.log(`Sent image to ${roomId}: ${mxcUrl}`)
+      if (this.threadIsolation) {
+        const session = this.sessionManager.get(context.sessionId)
+        const lastEventId = session?.lastEventIds.get(context.replyThreadRootId) || context.replyThreadRootId
+        content["m.relates_to"] = buildThreadRelation(context.replyThreadRootId, lastEventId)
+      }
+
+      const eventId = await this.matrix!.sendMessage(context.roomId, content)
+      if (this.threadIsolation) {
+        const session = this.sessionManager.get(context.sessionId)
+        if (session && eventId) {
+          session.lastEventIds.set(context.replyThreadRootId, eventId)
+        }
+      }
+
+      this.log(`Sent image to ${context.roomId}: ${mxcUrl}`)
     } catch (err) {
-      this.logError(`Failed to send image to ${roomId}:`, err)
-      await this.sendMessage(roomId, `[Image: ${image.alt || "Unable to display"}]`)
+      this.logError(`Failed to send image to ${context.roomId}:`, err)
+      await this.sendReply(context, `[Image: ${image.alt || "Unable to display"}]`)
     }
   }
 
-  private async sendImageFromFile(roomId: string, filePath: string): Promise<void> {
+  private async sendImageFromFile(context: MatrixEventContext, filePath: string): Promise<void> {
     try {
       if (!fs.existsSync(filePath)) {
         this.logError(`Image file not found: ${filePath}`)
@@ -560,19 +618,30 @@ class MatrixConnector extends BaseConnector<RoomSession> {
       const fileName = path.basename(filePath)
       const mxcUrl = await this.matrix!.uploadContent(buffer, "image/png", fileName)
 
-      await this.matrix!.sendMessage(roomId, {
+      const content: any = {
         msgtype: "m.image",
         body: fileName,
         url: mxcUrl,
-        info: {
-          mimetype: "image/png",
-          size: buffer.length,
-        },
-      })
+        info: { mimetype: "image/png", size: buffer.length },
+      }
 
-      this.log(`Sent image from file to ${roomId}: ${mxcUrl}`)
+      if (this.threadIsolation) {
+        const session = this.sessionManager.get(context.sessionId)
+        const lastEventId = session?.lastEventIds.get(context.replyThreadRootId) || context.replyThreadRootId
+        content["m.relates_to"] = buildThreadRelation(context.replyThreadRootId, lastEventId)
+      }
+
+      const eventId = await this.matrix!.sendMessage(context.roomId, content)
+      if (this.threadIsolation) {
+        const session = this.sessionManager.get(context.sessionId)
+        if (session && eventId) {
+          session.lastEventIds.set(context.replyThreadRootId, eventId)
+        }
+      }
+
+      this.log(`Sent image from file to ${context.roomId}: ${mxcUrl}`)
     } catch (err) {
-      this.logError(`Failed to send image from file to ${roomId}:`, err)
+      this.logError(`Failed to send image from file to ${context.roomId}:`, err)
     }
   }
 }
@@ -583,21 +652,14 @@ class MatrixConnector extends BaseConnector<RoomSession> {
 
 async function main() {
   const connector = new MatrixConnector()
-
-  // Handle shutdown
-  process.on("SIGINT", async () => {
-    await connector.stop()
-    process.exit(0)
-  })
-  process.on("SIGTERM", async () => {
-    await connector.stop()
-    process.exit(0)
-  })
-
+  process.on("SIGINT", async () => { await connector.stop(); process.exit(0) })
+  process.on("SIGTERM", async () => { await connector.stop(); process.exit(0) })
   await connector.start()
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err)
-  process.exit(1)
-})
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("Fatal error:", err)
+    process.exit(1)
+  })
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -276,7 +276,7 @@ varies by platform:
 | Platform | Session Key | Isolation |
 |----------|-------------|-----------|
 | Slack | `channel:threadTs` | Per-thread |
-| Matrix | `roomId` | Per-room |
+| Matrix | `roomId:threadRootEventId` | Per-thread |
 | Discord | `channelId` | Per-channel |
 | Mattermost | `channelId:rootId` | Per-thread |
 | WhatsApp | `chatId` | Per-chat |

--- a/docs/MATRIX_SETUP.md
+++ b/docs/MATRIX_SETUP.md
@@ -124,6 +124,26 @@ Or mention the bot directly:
 @my-opencode-bot what's the weather?
 ```
 
+### Thread Isolation
+
+When thread isolation is enabled (default), each Matrix thread gets its own session:
+
+- **Trigger or mention** in a room starts a new thread with its own session
+- **Replies within the thread** are forwarded automatically (using `m.thread` relations)
+- **Different threads** have completely separate sessions and context
+- **Clients without thread support** see replies as a reply chain (via `m.in_reply_to` fallback)
+
+Configure in `chat-bridge.json`:
+```json
+{
+  "matrix": {
+    "threadIsolation": true
+  }
+}
+```
+
+Set to `false` for per-room sessions (old behavior).
+
 ### Commands
 
 | Command | Description |

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface MatrixConfig {
   ignoreRooms: string[]
   ignoreUsers: string[]
   formatHtml: boolean
+  threadIsolation: boolean  // true: per-thread sessions + thread replies, false: per-room
 }
 
 export interface MattermostConfig {
@@ -85,7 +86,8 @@ const defaultConfig: ChatBridgeConfig = {
     triggerPatterns: ["!oc "],
     ignoreRooms: [],
     ignoreUsers: [],
-    formatHtml: false
+    formatHtml: false,
+    threadIsolation: true,  // Per-thread sessions by default
   },
   mattermost: {
     enabled: false,

--- a/tests/integration/matrix-event-mapping.test.ts
+++ b/tests/integration/matrix-event-mapping.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration tests for Matrix event-to-context mapping
+ */
+
+import { describe, test, expect } from "bun:test"
+import {
+  extractThreadRootId,
+  normalizeMatrixEventContext,
+  buildThreadRelation,
+} from "../../connectors/matrix-thread-helpers"
+
+describe("matrix event mapping integration", () => {
+  test("top-level trigger maps to new thread rooted at event_id", () => {
+    const ctx = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      sender: "@user:server",
+      text: "!oc hello",
+      eventId: "$evt001",
+    }, true)
+
+    expect(ctx.sessionId).toBe("!room:server:$evt001")
+    expect(ctx.replyThreadRootId).toBe("$evt001")
+
+    const relation = buildThreadRelation(ctx.replyThreadRootId, ctx.eventId)
+    expect((relation as any).event_id).toBe("$evt001")
+  })
+
+  test("thread reply maps to existing thread root", () => {
+    const event = {
+      event_id: "$evt002",
+      content: {
+        body: "follow up",
+        "m.relates_to": {
+          rel_type: "m.thread",
+          event_id: "$evt001",
+        },
+      },
+    }
+
+    const threadRoot = extractThreadRootId(event)
+    expect(threadRoot).toBe("$evt001")
+
+    const ctx = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      sender: "@user:server",
+      text: "follow up",
+      eventId: "$evt002",
+      threadRootEventId: threadRoot,
+    }, true)
+
+    expect(ctx.sessionId).toBe("!room:server:$evt001")
+    expect(ctx.replyThreadRootId).toBe("$evt001")
+  })
+
+  test("two threads in same room get different sessions", () => {
+    const ctx1 = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$evt001",
+    }, true)
+    const ctx2 = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$evt002",
+    }, true)
+
+    expect(ctx1.sessionId).not.toBe(ctx2.sessionId)
+  })
+
+  test("threadIsolation off gives same session for all threads", () => {
+    const ctx1 = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$evt001",
+    }, false)
+    const ctx2 = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$evt002",
+      threadRootEventId: "$evt001",
+    }, false)
+
+    expect(ctx1.sessionId).toBe(ctx2.sessionId)
+    expect(ctx1.sessionId).toBe("!room:server")
+  })
+})

--- a/tests/unit/matrix-thread-context.test.ts
+++ b/tests/unit/matrix-thread-context.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for Matrix thread context helpers
+ */
+
+import { describe, test, expect } from "bun:test"
+import {
+  extractThreadRootId,
+  resolveThreadRoot,
+  buildMatrixSessionId,
+  normalizeMatrixEventContext,
+  buildThreadRelation,
+  shouldHandleThreadReply,
+} from "../../connectors/matrix-thread-helpers"
+
+// =============================================================================
+// extractThreadRootId
+// =============================================================================
+
+describe("extractThreadRootId", () => {
+  test("extracts thread root from m.thread relation", () => {
+    const event = {
+      content: {
+        "m.relates_to": {
+          rel_type: "m.thread",
+          event_id: "$root123",
+        },
+      },
+    }
+    expect(extractThreadRootId(event)).toBe("$root123")
+  })
+
+  test("returns empty for non-threaded events", () => {
+    const event = { content: { body: "hello" } }
+    expect(extractThreadRootId(event)).toBe("")
+  })
+
+  test("returns empty for m.annotation relations", () => {
+    const event = {
+      content: {
+        "m.relates_to": {
+          rel_type: "m.annotation",
+          event_id: "$some_event",
+          key: "thumbsup",
+        },
+      },
+    }
+    expect(extractThreadRootId(event)).toBe("")
+  })
+
+  test("returns empty for missing content", () => {
+    expect(extractThreadRootId({})).toBe("")
+    expect(extractThreadRootId(null)).toBe("")
+    expect(extractThreadRootId(undefined)).toBe("")
+  })
+})
+
+// =============================================================================
+// resolveThreadRoot
+// =============================================================================
+
+describe("resolveThreadRoot", () => {
+  test("uses eventId when no thread root", () => {
+    expect(resolveThreadRoot("", "$event456")).toBe("$event456")
+  })
+
+  test("uses thread root when present", () => {
+    expect(resolveThreadRoot("$root123", "$event456")).toBe("$root123")
+  })
+})
+
+// =============================================================================
+// buildMatrixSessionId
+// =============================================================================
+
+describe("buildMatrixSessionId", () => {
+  test("returns room:threadRoot when isolation is on", () => {
+    expect(buildMatrixSessionId("!room:server", "$root1", true)).toBe("!room:server:$root1")
+  })
+
+  test("returns plain room when isolation is off", () => {
+    expect(buildMatrixSessionId("!room:server", "$root1", false)).toBe("!room:server")
+  })
+
+  test("two threads in same room get different IDs when on", () => {
+    const id1 = buildMatrixSessionId("!room:server", "$root1", true)
+    const id2 = buildMatrixSessionId("!room:server", "$root2", true)
+    expect(id1).not.toBe(id2)
+  })
+
+  test("two threads in same room get same ID when off", () => {
+    const id1 = buildMatrixSessionId("!room:server", "$root1", false)
+    const id2 = buildMatrixSessionId("!room:server", "$root2", false)
+    expect(id1).toBe(id2)
+  })
+})
+
+// =============================================================================
+// normalizeMatrixEventContext
+// =============================================================================
+
+describe("normalizeMatrixEventContext", () => {
+  test("normalizes threaded event with isolation on", () => {
+    const ctx = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      sender: "@user:server",
+      text: "follow up",
+      eventId: "$event222",
+      threadRootEventId: "$root111",
+    }, true)
+
+    expect(ctx.sessionId).toBe("!room:server:$root111")
+    expect(ctx.replyThreadRootId).toBe("$root111")
+    expect(ctx.dedupeId).toBe("$event222")
+  })
+
+  test("top-level message uses eventId as thread root", () => {
+    const ctx = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$event333",
+    }, true)
+
+    expect(ctx.sessionId).toBe("!room:server:$event333")
+    expect(ctx.replyThreadRootId).toBe("$event333")
+  })
+
+  test("uses room as session ID when isolation is off", () => {
+    const ctx = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$event444",
+      threadRootEventId: "$root111",
+    }, false)
+
+    expect(ctx.sessionId).toBe("!room:server")
+  })
+
+  test("handles missing optional fields", () => {
+    const ctx = normalizeMatrixEventContext({
+      roomId: "!room:server",
+      eventId: "$event555",
+    }, true)
+
+    expect(ctx.sender).toBe("unknown")
+    expect(ctx.text).toBe("")
+    expect(ctx.threadRootEventId).toBe("")
+  })
+})
+
+// =============================================================================
+// buildThreadRelation
+// =============================================================================
+
+describe("buildThreadRelation", () => {
+  test("builds correct m.thread relation", () => {
+    const relation = buildThreadRelation("$root123", "$last456")
+    expect(relation).toEqual({
+      rel_type: "m.thread",
+      event_id: "$root123",
+      is_falling_back: true,
+      "m.in_reply_to": {
+        event_id: "$last456",
+      },
+    })
+  })
+})
+
+// =============================================================================
+// shouldHandleThreadReply
+// =============================================================================
+
+describe("shouldHandleThreadReply", () => {
+  test("accepts plain thread replies", () => {
+    expect(shouldHandleThreadReply({
+      text: "continue this",
+      threadRootEventId: "$root123",
+      trigger: "!oc",
+      botUserId: "@bot:server",
+    })).toBe(true)
+  })
+
+  test("rejects non-thread messages", () => {
+    expect(shouldHandleThreadReply({
+      text: "hello",
+      threadRootEventId: "",
+      trigger: "!oc",
+      botUserId: "@bot:server",
+    })).toBe(false)
+  })
+
+  test("rejects trigger-prefixed messages", () => {
+    expect(shouldHandleThreadReply({
+      text: "!oc query",
+      threadRootEventId: "$root123",
+      trigger: "!oc",
+      botUserId: "@bot:server",
+    })).toBe(false)
+  })
+
+  test("rejects messages mentioning bot", () => {
+    expect(shouldHandleThreadReply({
+      text: "hey @bot:server what do you think",
+      threadRootEventId: "$root123",
+      trigger: "!oc",
+      botUserId: "@bot:server",
+    })).toBe(false)
+  })
+
+  test("rejects empty text", () => {
+    expect(shouldHandleThreadReply({
+      text: "",
+      threadRootEventId: "$root123",
+      trigger: "!oc",
+      botUserId: "@bot:server",
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- **Per-thread session isolation for Matrix** using MSC3440 `m.thread` relations
- Sessions keyed on `room:threadRootEventId`, configurable via `matrix.threadIsolation` (default: true)
- 24 new tests (20 unit + 4 integration), 164 total passing
- Live-tested on Element: thread replies, implicit follow-ups, session isolation all confirmed

## Key design decisions

- **Helpers extracted to `matrix-thread-helpers.ts`** -- standalone file with no `matrix-bot-sdk` dependency, so tests run without the SDK installed
- **`m.in_reply_to` fallback** -- every thread reply includes fallback for clients without thread support
- **`lastEventIds` tracking** -- each session tracks the last event ID per thread for correct reply chaining
- **Images also threaded** -- file and base64 image uploads include `m.relates_to` when isolation is on

## Config

```json
{
  "matrix": {
    "threadIsolation": true
  }
}
```

## Live test results

Tested in unencrypted Element room:
- Thread replies: bot responds inside threads with `m.thread` relation
- Implicit follow-ups: plain thread replies forwarded without trigger
- Thread isolation: separate threads have separate sessions
- Commands (`/clear`) work within thread context

## Related

- Partially addresses #13 (Matrix done, Discord remains)