### PR TITLE
fix: skip sanitizeServerPaths when message contains URLs

### DIFF
--- a/src/session-utils.ts
+++ b/src/session-utils.ts
@@ -291,6 +291,8 @@ export function removeImageMarkers(text: string): string {
  * @returns Text with absolute paths replaced by filenames
  */
 export function sanitizeServerPaths(text: string): string {
+  // Skip if message contains URLs (http/https) to avoid mangling them
+  if (/https?:\/\//i.test(text)) return text;
   // Match absolute paths: /path/to/filename.ext
   // Captures paths starting with / followed by path segments and a filename with extension
   return text.replace(


### PR DESCRIPTION
## Summary

- `sanitizeServerPaths()` strips absolute paths down to filenames (e.g. `/home/user/file.jpg` -> `file.jpg`), but the regex also matches URL paths, mangling links like `https://example.com/path/file.jpg` into just `file.jpg`.
- Fix: skip the entire transform when the text contains `http(s)://` URLs, preserving user-facing links.