### PR TITLE
Fix empty responses caused by race condition in prompt()

### DIFF
--- a/connectors/web.ts
+++ b/connectors/web.ts
@@ -482,6 +482,9 @@ class WebConnector extends BaseConnector<WebSession> {
 
       const clean = sanitizeServerPaths(removeDocMarkers(removeImageMarkers(buf)))
       session.outputChars += clean.length
+      if (!clean && tools > 0) {
+        this.wsSend(clientId, { type: "chunk", text: "He procesado la consulta pero no he podido generar una respuesta. Intentalo de nuevo." })
+      }
       this.wsSend(clientId, { type: "done" })
 
       const sec = ((Date.now() - t0) / 1000).toFixed(1)

--- a/connectors/whatsapp.ts
+++ b/connectors/whatsapp.ts
@@ -359,8 +359,14 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
     client.on("image", imageHandler)
     client.on("permission_rejected", permissionHandler)
 
+    // Timeout to prevent stuck requests (5 minutes)
+    const QUERY_TIMEOUT_MS = 5 * 60 * 1000
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Request timed out")), QUERY_TIMEOUT_MS)
+    )
+
     try {
-      await client.prompt(query)
+      await Promise.race([client.prompt(query), timeoutPromise])
 
       // Process images from tool results
       const uploadedPaths = new Set<string>()
@@ -409,6 +415,8 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
       if (cleanResponse) {
         session.outputChars += cleanResponse.length
         await this.sendMessage(chatId, cleanResponse)
+      } else if (toolCallCount > 0) {
+        await this.sendMessage(chatId, "He procesado la consulta pero no he podido generar una respuesta. Intentalo de nuevo.")
       }
       // Log elapsed time
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -94,6 +94,8 @@ export class ACPClient extends EventEmitter {
   private _availableCommands: OpenCodeCommand[] = []
   // Track cumulative output per tool call to compute actual deltas
   private toolOutputSeen = new Map<string, number>()
+  // Track tool calls we already emitted activity for (dedup)
+  private toolActivityEmitted = new Set<string>()
   
   constructor(options: ACPClientOptions = {}) {
     super()
@@ -178,6 +180,10 @@ export class ACPClient extends EventEmitter {
     
     dbg(`PROMPT_START sessionId=${this.sessionId}`)
     
+    // Reset per-prompt tracking
+    this.toolOutputSeen.clear()
+    this.toolActivityEmitted.clear()
+    
     let responseText = ""
     let currentThought = ""
     
@@ -204,7 +210,18 @@ export class ACPClient extends EventEmitter {
     }
     
     await this.send("session/prompt", params)
-    dbg(`PROMPT_SEND_DONE`)
+    dbg(`PROMPT_SEND_DONE total=${responseText.length}`)
+    
+    // Drain: the JSON-RPC response can arrive before trailing session/update
+    // notifications (text chunks). Wait for the event loop to flush them.
+    // If still empty after drain, wait a bit longer with backoff.
+    if (!responseText) {
+      for (const ms of [10, 50, 200]) {
+        await new Promise(r => setTimeout(r, ms))
+        dbg(`DRAIN_WAIT ${ms}ms total=${responseText.length}`)
+        if (responseText) break
+      }
+    }
     
     this.off("update", updateHandler)
     dbg(`PROMPT_HANDLER_UNREGISTERED total=${responseText.length}`)
@@ -391,15 +408,19 @@ export class ACPClient extends EventEmitter {
           })
           this.emit("tool", { name: toolNameUpdate, status: update.status, args: toolArgsUpdate })
           
-          // Emit human-readable activity event with actual tool name for transparency
-          const activity = this.formatToolActivity(toolNameUpdate, toolArgsUpdate, "start")
-          this.emit("activity", {
-            type: "tool_start",
-            tool: activity.toolName,
-            message: `${activity.description} [${activity.toolName}]`,
-            description: activity.description,
-            details: toolArgsUpdate,
-          })
+          // Emit human-readable activity event -- only once per tool call
+          const tcId = update.toolCallId || toolNameUpdate
+          if (!this.toolActivityEmitted.has(tcId)) {
+            this.toolActivityEmitted.add(tcId)
+            const activity = this.formatToolActivity(toolNameUpdate, toolArgsUpdate, "start")
+            this.emit("activity", {
+              type: "tool_start",
+              tool: activity.toolName,
+              message: `${activity.description} [${activity.toolName}]`,
+              description: activity.description,
+              details: toolArgsUpdate,
+            })
+          }
           
           // Stream partial output if available (e.g., bash stdout during execution)
           // rawOutput.output is CUMULATIVE - compute actual delta


### PR DESCRIPTION
## Summary

- **Race condition fix**: `prompt()` in `acp-client.ts` unregisters its text handler the moment the JSON-RPC response arrives, but `session/update` text notifications arrive 2-3ms later. Added a drain loop with backoff (10/50/200ms) to catch trailing events.
- **Activity dedup**: `tool_call_update` with `in_progress` status fires multiple times per tool call, causing duplicate notifications. Now tracks emitted tool call IDs.
- **Empty response fallback**: Both connectors now send a user-facing message instead of silence when tools ran but no text was generated.
- **WhatsApp timeout**: Added 5-minute `Promise.race` timeout (web already had it).

## Evidence

Debug log showing the race condition (before fix):
```
13:37:32.418  RESOLVE_PENDING id=3              <-- prompt() resolves
13:37:32.418  PROMPT_HANDLER_UNREGISTERED total=0   <-- handler removed, 0 chars!
13:37:32.420  agent_message_chunk "Hey! ..."       <-- text arrives 2ms LATER
```

After fix:
```
15.433  PROMPT_SEND_DONE total=0
15.436  PROMPT_HANDLER text="Hey!..."     <-- handler still active, catches text
15.442  DRAIN_WAIT 10ms total=166         <-- drain confirms
15.442  HANDLER_UNREGISTERED total=166
```

## Test plan

- [x] Tested on web widget: simple greetings, tool queries (fleet, warehouse)
- [x] Tested on WhatsApp: fleet queries, school queries
- [x] Verified drain only activates when needed (no delay when text arrives before response)
- [x] Verified activity dedup: each tool notification shown only once
- [x] 26+ documented cases of 0-char responses in production since March 2026