### PR TITLE
fix(whatsapp): implement request cancellation and resolve sync timeouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -423,7 +423,7 @@
 
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
-    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d"],
+    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d", "sha512-5q4/OuDQaMYx3RpDqMqS3WYyqjrsSMpU8ipQZtpYnm5l6DwNoLV9oIYMDK0NILKW+tyk3tVCIA11BMYQ+A1+GA=="],
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 

--- a/connectors/whatsapp.ts
+++ b/connectors/whatsapp.ts
@@ -23,6 +23,7 @@ import makeWASocket, {
   DisconnectReason,
   fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,
+  SyncState,
 } from "baileys"
 import { Boom } from "@hapi/boom"
 import * as qrcode from "qrcode-terminal"
@@ -176,7 +177,7 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
 
     // Handle connection updates
     this.sock.ev.on("connection.update", async (update) => {
-      const { connection, lastDisconnect, qr } = update
+      const { connection, lastDisconnect, qr, receivedPendingNotifications } = update
 
       if (qr) {
         console.log("\n=== Scan this QR code with WhatsApp ===\n")
@@ -204,6 +205,10 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
         console.log(`  My number: ${this.myNumber}`)
         this.log("Listening for messages...")
       }
+
+      if (receivedPendingNotifications) {
+        this.log("Initial sync complete (received all pending notifications).")
+      }
     })
 
     // Save credentials on update
@@ -211,7 +216,17 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
 
     // Handle incoming messages
     this.sock.ev.on("messages.upsert", async ({ messages, type }) => {
+      if (type !== "notify") {
+        if (type === "append") {
+          this.log(`Ignoring history sync messages (type: ${type})`)
+        } else {
+          this.log(`Ignoring non-notify upsert (type: ${type})`)
+        }
+        return
+      }
+
       for (const msg of messages) {
+
         await this.handleMessage(msg)
       }
     })
@@ -283,10 +298,9 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
 
     // Guard against concurrent queries on the same session
     if (this.isQueryActive(chatId)) {
-      await this.sendMessage(chatId, "A request is already running. Please wait for it to finish.")
-      return
+      this.log(`[ABORT] New query from ${phoneNumber}, aborting previous...`)
+      this.abortQuery(chatId)
     }
-    this.markQueryActive(chatId)
 
     // Get or create session
     const session = await this.getOrCreateSession(chatId, (client) =>
@@ -298,10 +312,17 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
       return
     }
 
-    // Update session stats
-    session.messageCount++
-    session.lastActivity = new Date()
-    session.inputChars += query.length
+    this.markQueryActive(chatId, () => {
+      this.log(`[ABORT-EXEC] Disconnecting ACP client for ${chatId}`)
+      session.client.disconnect()
+    })
+
+    try {
+      // Update session stats
+      session.messageCount++
+      session.lastActivity = new Date()
+      session.inputChars += query.length
+
 
     const client = session.client
 

--- a/connectors/whatsapp.ts
+++ b/connectors/whatsapp.ts
@@ -23,7 +23,6 @@ import makeWASocket, {
   DisconnectReason,
   fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,
-  SyncState,
 } from "baileys"
 import { Boom } from "@hapi/boom"
 import * as qrcode from "qrcode-terminal"
@@ -296,7 +295,8 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
   private async processQuery(chatId: string, phoneNumber: string, query: string): Promise<void> {
     const startTime = Date.now()
 
-    // Guard against concurrent queries on the same session
+    // WhatsApp uses "latest message wins": abort the old OpenCode process and
+    // drop its cached session so the new request never reuses a disconnected client.
     if (this.isQueryActive(chatId)) {
       this.log(`[ABORT] New query from ${phoneNumber}, aborting previous...`)
       this.abortQuery(chatId)
@@ -312,17 +312,16 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
       return
     }
 
-    this.markQueryActive(chatId, () => {
+    const activeQuery = this.markQueryActive(chatId, () => {
       this.log(`[ABORT-EXEC] Disconnecting ACP client for ${chatId}`)
-      session.client.disconnect()
+      this.sessionManager.delete(chatId)
+      void session.client.disconnect()
     })
 
-    try {
-      // Update session stats
-      session.messageCount++
-      session.lastActivity = new Date()
-      session.inputChars += query.length
-
+    // Update session stats
+    session.messageCount++
+    session.lastActivity = new Date()
+    session.inputChars += query.length
 
     const client = session.client
 
@@ -376,9 +375,10 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
 
     // Timeout to prevent stuck requests (5 minutes)
     const QUERY_TIMEOUT_MS = 5 * 60 * 1000
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), QUERY_TIMEOUT_MS)
-    )
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error("Request timed out")), QUERY_TIMEOUT_MS)
+    })
 
     try {
       await Promise.race([client.prompt(query), timeoutPromise])
@@ -440,16 +440,21 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
       this.log(`[DONE] ${elapsed}s (${outChars} chars${tools})`)
     } catch (err) {
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-      this.logError(`[FAIL] ${elapsed}s:`, err)
-      await this.sendMessage(chatId, "Sorry, something went wrong processing your request.")
+      if (this.wasQueryAborted(activeQuery)) {
+        this.log(`[CANCELLED] ${elapsed}s: superseded by a newer WhatsApp query`)
+      } else {
+        this.logError(`[FAIL] ${elapsed}s:`, err)
+        await this.sendMessage(chatId, "Sorry, something went wrong processing your request.")
+      }
     } finally {
+      if (timeoutId) clearTimeout(timeoutId)
       client.off("activity", activityHandler)
       client.off("chunk", chunkHandler)
       client.off("update", updateHandler)
       client.off("image", imageHandler)
       client.off("permission_rejected", permissionHandler)
-      if (session) session.lastActivity = new Date()
-      this.markQueryDone(chatId)
+      session.lastActivity = new Date()
+      this.markQueryDone(chatId, activeQuery)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build": "bun build src/index.ts --outdir dist --target node --format esm",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "check:connectors": "for f in connectors/*.ts; do bun build \"$f\" --outdir /tmp/opencode-chat-bridge-connector-check --target node --format esm >/dev/null || exit 1; done",
+    "check": "bun run typecheck && bun test && bun run check:connectors",
     "matrix": "bun connectors/matrix.ts",
     "slack": "bun connectors/slack.ts",
     "whatsapp": "bun connectors/whatsapp.ts",

--- a/src/acp-client.ts
+++ b/src/acp-client.ts
@@ -86,7 +86,7 @@ export interface OpenCodeCommand {
 export class ACPClient extends EventEmitter {
   private acp: ChildProcess | null = null
   private requestId = 0
-  private pending = new Map<number, (msg: any) => void>()
+  private pending = new Map<number, { resolve: (msg: any) => void; reject: (err: Error) => void }>()
   private buffer = ""
   private sessionId: string | null = null
   private cwd: string
@@ -135,7 +135,14 @@ export class ACPClient extends EventEmitter {
         this.emit("error", text)
       }
     })
-    this.acp.on("close", (code) => this.emit("close", code))
+    this.acp.on("error", (err) => {
+      this.rejectPending(err instanceof Error ? err : new Error(String(err)))
+      this.emit("error", err)
+    })
+    this.acp.on("close", (code) => {
+      this.rejectPending(new Error(`ACP process exited${code === null ? "" : ` with code ${code}`}`))
+      this.emit("close", code)
+    })
     
     // Wait for process to start
     await this.sleep(300)
@@ -209,24 +216,26 @@ export class ACPClient extends EventEmitter {
       params.agent = options.agent
     }
     
-    await this.send("session/prompt", params)
-    dbg(`PROMPT_SEND_DONE total=${responseText.length}`)
-    
-    // Drain: the JSON-RPC response can arrive before trailing session/update
-    // notifications (text chunks). Wait for the event loop to flush them.
-    // If still empty after drain, wait a bit longer with backoff.
-    if (!responseText) {
-      for (const ms of [10, 50, 200]) {
-        await new Promise(r => setTimeout(r, ms))
-        dbg(`DRAIN_WAIT ${ms}ms total=${responseText.length}`)
-        if (responseText) break
+    try {
+      await this.send("session/prompt", params)
+      dbg(`PROMPT_SEND_DONE total=${responseText.length}`)
+      
+      // Drain: the JSON-RPC response can arrive before trailing session/update
+      // notifications (text chunks). Wait for the event loop to flush them.
+      // If still empty after drain, wait a bit longer with backoff.
+      if (!responseText) {
+        for (const ms of [10, 50, 200]) {
+          await new Promise(r => setTimeout(r, ms))
+          dbg(`DRAIN_WAIT ${ms}ms total=${responseText.length}`)
+          if (responseText) break
+        }
       }
+      
+      return responseText
+    } finally {
+      this.off("update", updateHandler)
+      dbg(`PROMPT_HANDLER_UNREGISTERED total=${responseText.length}`)
     }
-    
-    this.off("update", updateHandler)
-    dbg(`PROMPT_HANDLER_UNREGISTERED total=${responseText.length}`)
-    
-    return responseText
   }
   
   async disconnect(): Promise<void> {
@@ -234,16 +243,34 @@ export class ACPClient extends EventEmitter {
       this.acp.kill()
       this.acp = null
     }
+    this.rejectPending(new Error("ACP client disconnected"))
     this.sessionId = null
   }
   
   private send(method: string, params: any = {}): Promise<any> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      if (!this.acp || !this.acp.stdin || this.acp.killed || this.acp.stdin.destroyed) {
+        reject(new Error("ACP client is not connected"))
+        return
+      }
+
       const id = ++this.requestId
       const msg = { jsonrpc: "2.0", id, method, params }
-      this.pending.set(id, resolve)
-      this.acp!.stdin!.write(JSON.stringify(msg) + "\n")
+      this.pending.set(id, { resolve, reject })
+      this.acp.stdin.write(JSON.stringify(msg) + "\n", (err) => {
+        if (err) {
+          this.pending.delete(id)
+          reject(err)
+        }
+      })
     })
+  }
+
+  private rejectPending(err: Error): void {
+    for (const { reject } of this.pending.values()) {
+      reject(err)
+    }
+    this.pending.clear()
   }
   
   private handleData(data: Buffer): void {
@@ -281,9 +308,9 @@ export class ACPClient extends EventEmitter {
     // Handle responses
     if (msg.id && this.pending.has(msg.id)) {
       dbg(`RESOLVE_PENDING id=${msg.id}`)
-      const resolve = this.pending.get(msg.id)!
+      const pending = this.pending.get(msg.id)!
       this.pending.delete(msg.id)
-      resolve(msg)
+      pending.resolve(msg)
     }
   }
   

--- a/src/connector-base.ts
+++ b/src/connector-base.ts
@@ -337,7 +337,7 @@ export abstract class BaseConnector<TSession extends BaseSession> {
   protected config: ConnectorConfig
   private eventDeduplicator: EventDeduplicator
   /** Session IDs with an in-flight query -- never evict these */
-  protected activeQueries = new Set<string>()
+  protected activeQueries = new Map<string, { abort: () => void }>()
   private allowedUsers: Set<string> | null = null
   private expiryInterval: NodeJS.Timeout | null = null
   
@@ -442,10 +442,11 @@ export abstract class BaseConnector<TSession extends BaseSession> {
   
   /**
    * Mark a session as having an active query.
-   * Call before starting prompt processing.
+   * @param sessionId Session ID
+   * @param abortFn Optional callback to abort the query
    */
-  protected markQueryActive(sessionId: string): void {
-    this.activeQueries.add(sessionId)
+  protected markQueryActive(sessionId: string, abortFn: () => void = () => {}): void {
+    this.activeQueries.set(sessionId, { abort: abortFn })
   }
   
   /**
@@ -454,6 +455,17 @@ export abstract class BaseConnector<TSession extends BaseSession> {
    */
   protected markQueryDone(sessionId: string): void {
     this.activeQueries.delete(sessionId)
+  }
+
+  /**
+   * Abort an active query for the given session.
+   */
+  protected abortQuery(sessionId: string): void {
+    const active = this.activeQueries.get(sessionId)
+    if (active) {
+      active.abort()
+      this.activeQueries.delete(sessionId)
+    }
   }
   
   // ---------------------------------------------------------------------------

--- a/src/connector-base.ts
+++ b/src/connector-base.ts
@@ -46,6 +46,16 @@ export interface SessionStats {
 }
 
 /**
+ * Opaque handle for an in-flight query.
+ * Pass it back to markQueryDone() so stale/aborted requests cannot clear newer ones.
+ */
+export interface ActiveQueryHandle {
+  readonly sessionId: string
+  readonly id: number
+  readonly aborted: boolean
+}
+
+/**
  * Configuration for BaseConnector
  */
 export interface ConnectorConfig {
@@ -337,7 +347,8 @@ export abstract class BaseConnector<TSession extends BaseSession> {
   protected config: ConnectorConfig
   private eventDeduplicator: EventDeduplicator
   /** Session IDs with an in-flight query -- never evict these */
-  protected activeQueries = new Map<string, { abort: () => void }>()
+  protected activeQueries = new Map<string, ActiveQueryHandle & { abort: () => void; aborted: boolean }>()
+  private nextActiveQueryId = 0
   private allowedUsers: Set<string> | null = null
   private expiryInterval: NodeJS.Timeout | null = null
   
@@ -445,27 +456,61 @@ export abstract class BaseConnector<TSession extends BaseSession> {
    * @param sessionId Session ID
    * @param abortFn Optional callback to abort the query
    */
-  protected markQueryActive(sessionId: string, abortFn: () => void = () => {}): void {
-    this.activeQueries.set(sessionId, { abort: abortFn })
+  protected markQueryActive(sessionId: string, abortFn: () => void = () => {}): ActiveQueryHandle {
+    const active = {
+      sessionId,
+      id: ++this.nextActiveQueryId,
+      aborted: false,
+      abort: abortFn,
+    }
+    this.activeQueries.set(sessionId, active)
+    return active
   }
   
   /**
    * Mark a session query as complete.
-   * Call in the finally block after prompt processing.
+   * Pass the handle returned by markQueryActive() to avoid a stale query clearing
+   * a newer active query for the same session.
    */
-  protected markQueryDone(sessionId: string): void {
-    this.activeQueries.delete(sessionId)
+  protected markQueryDone(sessionId: string, handle?: ActiveQueryHandle): void {
+    if (!handle) {
+      this.activeQueries.delete(sessionId)
+      return
+    }
+
+    const current = this.activeQueries.get(sessionId)
+    if (current?.id === handle.id) {
+      this.activeQueries.delete(sessionId)
+    }
+  }
+
+  /**
+   * Check whether a query handle was intentionally aborted.
+   */
+  protected wasQueryAborted(handle: ActiveQueryHandle): boolean {
+    return handle.aborted
   }
 
   /**
    * Abort an active query for the given session.
    */
-  protected abortQuery(sessionId: string): void {
+  protected abortQuery(sessionId: string): boolean {
     const active = this.activeQueries.get(sessionId)
-    if (active) {
+    if (!active) return false
+
+    active.aborted = true
+    try {
       active.abort()
-      this.activeQueries.delete(sessionId)
+    } catch (err) {
+      this.logError(`[ABORT] Failed to abort active query for ${sessionId}:`, err)
+    } finally {
+      const current = this.activeQueries.get(sessionId)
+      if (current?.id === active.id) {
+        this.activeQueries.delete(sessionId)
+      }
     }
+
+    return true
   }
   
   // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   type BaseSession,
   type SessionStats,
   type ConnectorConfig,
+  type ActiveQueryHandle,
 } from "./connector-base"
 
 export { ImageHandler, type ImageUploadCallback, DocHandler, type DocUploadCallback } from "./image-handler"

--- a/start.sh
+++ b/start.sh
@@ -26,7 +26,7 @@ if curl -s http://127.0.0.1:4096/session > /dev/null 2>&1; then
     echo "OpenCode server already running on port 4096"
 else
     echo "Starting OpenCode server..."
-    /home/ominiverdi/.opencode/bin/opencode serve --port 4096 &
+    opencode serve --port 4096 &
     sleep 3
 fi
 

--- a/tests/unit/connector-base.test.ts
+++ b/tests/unit/connector-base.test.ts
@@ -69,6 +69,47 @@ describe("RateLimiter", () => {
 // Shared helpers
 // =============================================================================
 
+class TestConnector extends BaseConnector<BaseSession> {
+  constructor(allowedUsers?: string[]) {
+    super({
+      connector: "test",
+      trigger: "!oc",
+      botName: "Test",
+      rateLimitSeconds: 5,
+      sessionRetentionDays: 7,
+      allowedUsers,
+    })
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async sendMessage(): Promise<void> {}
+
+  public canUserAccess(userId: string): boolean {
+    return this.isUserAllowed(userId)
+  }
+
+  public startQuery(sessionId: string, abortFn?: () => void) {
+    return this.markQueryActive(sessionId, abortFn)
+  }
+
+  public finishQuery(sessionId: string, handle?: ReturnType<TestConnector["startQuery"]>): void {
+    this.markQueryDone(sessionId, handle)
+  }
+
+  public hasActiveQuery(sessionId: string): boolean {
+    return this.isQueryActive(sessionId)
+  }
+
+  public cancelQuery(sessionId: string): boolean {
+    return this.abortQuery(sessionId)
+  }
+
+  public isAborted(handle: ReturnType<TestConnector["startQuery"]>): boolean {
+    return this.wasQueryAborted(handle)
+  }
+}
+
 describe("parseCsvList", () => {
   test("parses comma-separated values", () => {
     expect(parseCsvList("a, b ,c")).toEqual(["a", "b", "c"])
@@ -85,27 +126,6 @@ describe("parseCsvList", () => {
 })
 
 describe("BaseConnector allowlist", () => {
-  class TestConnector extends BaseConnector<BaseSession> {
-    constructor(allowedUsers?: string[]) {
-      super({
-        connector: "test",
-        trigger: "!oc",
-        botName: "Test",
-        rateLimitSeconds: 5,
-        sessionRetentionDays: 7,
-        allowedUsers,
-      })
-    }
-
-    async start(): Promise<void> {}
-    async stop(): Promise<void> {}
-    async sendMessage(): Promise<void> {}
-
-    public canUserAccess(userId: string): boolean {
-      return this.isUserAllowed(userId)
-    }
-  }
-
   test("allows all users when allowlist is empty", () => {
     const connector = new TestConnector([])
     expect(connector.canUserAccess("user-1")).toBe(true)
@@ -119,6 +139,42 @@ describe("BaseConnector allowlist", () => {
   test("blocks unlisted users", () => {
     const connector = new TestConnector(["user-1", "user-2"])
     expect(connector.canUserAccess("user-3")).toBe(false)
+  })
+})
+
+describe("BaseConnector active query handles", () => {
+  test("tracks active queries", () => {
+    const connector = new TestConnector()
+    const handle = connector.startQuery("session-1")
+
+    expect(connector.hasActiveQuery("session-1")).toBe(true)
+
+    connector.finishQuery("session-1", handle)
+    expect(connector.hasActiveQuery("session-1")).toBe(false)
+  })
+
+  test("stale query handle cannot clear newer active query", () => {
+    const connector = new TestConnector()
+    const oldHandle = connector.startQuery("session-1")
+    const newHandle = connector.startQuery("session-1")
+
+    connector.finishQuery("session-1", oldHandle)
+    expect(connector.hasActiveQuery("session-1")).toBe(true)
+
+    connector.finishQuery("session-1", newHandle)
+    expect(connector.hasActiveQuery("session-1")).toBe(false)
+  })
+
+  test("abort marks handle as aborted and invokes abort callback", () => {
+    const connector = new TestConnector()
+    let aborted = false
+    const handle = connector.startQuery("session-1", () => { aborted = true })
+
+    expect(connector.cancelQuery("session-1")).toBe(true)
+
+    expect(aborted).toBe(true)
+    expect(connector.isAborted(handle)).toBe(true)
+    expect(connector.hasActiveQuery("session-1")).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
This PR addresses critical stability issues in the WhatsApp connector and standardizes request management across all connectors.

### Key Changes
- **Request Cancellation**: Refactored `activeQueries` in `BaseConnector` to use a `Map` that stores cancellation callbacks.
- **WhatsApp Auto-Abort**: When a new query is received on the same chat, the previous pending query is automatically cancelled (killing the underlying `opencode` process) to allow the new one to run immediately.
- **Sync Timeout Fix**: Filtered out `history sync` messages (`type === "append"`) in the WhatsApp listener. This prevents Baileys from hitting internal `waitForMessage` timeouts during session initialization.
- **Observability**: Added logging for connection sync events to better monitor session readiness.

### Benefits
- Resolves the "A request is already running" block by allowing new requests to take priority.
- Stabilizes WhatsApp connectivity during the initial historical data sync phase.