### PR TITLE
WIP: feat(telegram): add Telegram connector with per-topic session isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,7 @@ MATTERMOST_TOKEN=your_bot_access_token
 # MATRIX_TRIGGER=!oc
 # MATTERMOST_TRIGGER=!oc
 # WHATSAPP_TRIGGER=!oc
+# TELEGRAM_TRIGGER=!oc
 
 # Session retention period in days (default: 7)
 # Sessions older than this are cleaned up on connector startup
@@ -107,6 +108,21 @@ DISCORD_TOKEN=your_discord_bot_token
 # IRC_SERVER=irc.libera.chat
 # IRC_NICK=oc-bot
 # IRC_PASSWORD=your_password
+
+# ===================
+# Telegram Connector
+# ===================
+# See docs/TELEGRAM_SETUP.md for detailed instructions
+
+# Bot token from @BotFather on Telegram
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+
+# Restrict bot access to specific Telegram user IDs (comma-separated, optional)
+# Leave empty to respond to everyone who messages the bot
+# TELEGRAM_ALLOWED_USERS=123456789,987654321
+
+# Drop updates that arrived while the bot was offline (default: process backlog)
+# TELEGRAM_DROP_PENDING=1
 
 # ===================
 # Web Connector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Universal user allowlists (Slack, WhatsApp, Matrix, Discord, Mattermost)** -
+- **Telegram connector** - New connector using the Telegram Bot API over HTTPS
+  with native `fetch` and long-polling `getUpdates`. Zero external runtime
+  dependencies, no public port or webhook required. Features:
+  - Trigger-prefixed messages (`!oc ...`), `@`-mentions of the bot, and
+    auto-handled DMs (no prefix required in private chats)
+  - Per-topic session isolation in forum supergroups, configurable via
+    `threadIsolation` in `chat-bridge.json` (default `true`); each topic gets
+    its own isolated OpenCode session
+  - Plain replies inside an active topic continue the conversation without
+    requiring a re-mention (mirrors the behavior of the Slack/Mattermost
+    thread-isolation feature)
+  - Native image (`sendPhoto`) and document (`sendDocument`) uploads for
+    outputs from OpenCode tools
+  - Long-message splitting at the 4096-char Telegram limit
+  - `sendChatAction` "typing..." indicator while OpenCode is processing
+  - Automatic exponential-backoff polling with `retry_after` honored for 429s
+  - `allowedUsers` / `TELEGRAM_ALLOWED_USERS` allowlist plus `ignoreChats`
+    and `ignoreUsers` blocklists
+  - `TELEGRAM_DROP_PENDING=1` to skip messages queued while offline
+- **Universal user allowlists (Slack, WhatsApp, Matrix, Discord, Mattermost, Telegram)** -
   Each connector now supports `allowedUsers` in `chat-bridge.json` plus
   per-connector `*_ALLOWED_USERS` env vars. Messages from unlisted users are
   silently dropped. Feature originated from PR #28 by @llvilanova and was
   generalized across all connectors.
-- **Thread isolation (Slack, Mattermost, Matrix)** - Sessions are now keyed per thread (`channel:threadTs`)
-  instead of per channel. Each Slack thread gets its own isolated OpenCode session.
-  Replies always stay in threads. Implicit follow-ups work without re-mentioning
-  the bot. Configurable via `threadIsolation` in chat-bridge.json (default: true).
+- **Thread isolation (Slack, Mattermost, Matrix, Telegram)** - Sessions are now keyed per thread (`channel:threadTs` for Slack/Mattermost,
+  `room:$eventId` for Matrix, or `chatId:messageThreadId` for Telegram forum
+  topics) instead of per channel. Each thread gets its own isolated OpenCode
+  session. Replies always stay in threads. Implicit follow-ups work without
+  re-mentioning the bot. Configurable via `threadIsolation` in
+  chat-bridge.json (default: true).
   Inspired by PR #2, reimplemented with proper separation of concerns.
 - **Event deduplication (all connectors)** - New `EventDeduplicator` in BaseConnector
   prevents duplicate event processing. Tracks recently seen event IDs with automatic

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM oven/bun:1-debian
 
 LABEL org.opencontainers.image.source="https://github.com/ominiverdi/opencode-chat-bridge"
-LABEL org.opencontainers.image.description="Bridge OpenCode AI to chat platforms (Discord, Slack, Matrix, WhatsApp)"
+LABEL org.opencontainers.image.description="Bridge OpenCode AI to chat platforms (Discord, Slack, Matrix, WhatsApp, Mattermost, Telegram)"
 LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
@@ -31,7 +31,7 @@ RUN mkdir -p /data/sessions /data/whatsapp-auth
 ENV SESSION_BASE_DIR=/data/sessions
 ENV WHATSAPP_AUTH_DIR=/data/whatsapp-auth
 
-# Connector to run (discord, slack, matrix, whatsapp, mattermost)
+# Connector to run (discord, slack, matrix, whatsapp, mattermost, telegram)
 ENV CONNECTOR=matrix
 
 # Entrypoint script

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Bridge [OpenCode](https://opencode.ai) to chat platforms with permission-based s
 
 ## Recent Changes
 
-- New cross-connector `allowedUsers` allowlists for Slack, WhatsApp, Matrix, Discord, and Mattermost
+- New cross-connector `allowedUsers` allowlists for Slack, WhatsApp, Matrix, Discord, Mattermost, and Telegram
+- New Telegram connector with per-topic sessions in forum supergroups
 - Breaking change: WhatsApp renamed `allowedNumbers` to `allowedUsers` and `WHATSAPP_ALLOWED_NUMBERS` to `WHATSAPP_ALLOWED_USERS`
-- Slack, Mattermost, and Matrix support per-thread session isolation
+- Slack, Mattermost, Matrix, and Telegram support per-thread session isolation
 
 ## Table of Contents
 
-- [Connectors](#connectors) -- Matrix, Slack, WhatsApp, Mattermost, Discord, Web
+- [Connectors](#connectors) -- Matrix, Slack, WhatsApp, Mattermost, Discord, Telegram, Web
 - [Quick Start](#quick-start)
 - [Usage](#usage)
 - [Permissions](#permissions)
@@ -52,6 +53,10 @@ Uses the Mattermost REST API v4 and WebSocket for real-time events. Zero externa
 
 Uses discord.js for real-time messaging. Supports @mentions and DMs.
 
+### Telegram
+
+Uses the Telegram Bot API (HTTPS) via native `fetch` and long-polling `getUpdates`. Zero external dependencies -- no webhook or public port needed. Supports @mentions, DMs, file uploads, message splitting, and per-topic sessions in forum supergroups.
+
 ### Web
 
 <img src="images/web_widget.png" width="400" alt="Web widget connector" />
@@ -77,10 +82,11 @@ bun connectors/slack.ts
 bun connectors/whatsapp.ts
 bun connectors/mattermost.ts
 bun connectors/discord.ts
+bun connectors/telegram.ts
 bun connectors/web.ts
 ```
 
-See setup guides: [Matrix](docs/MATRIX_SETUP.md) | [Slack](docs/SLACK_SETUP.md) | [Mattermost](docs/MATTERMOST_SETUP.md) | [WhatsApp](docs/WHATSAPP_SETUP.md) | [Discord](docs/DISCORD_SETUP.md) | [Web](docs/WEB_SETUP.md)
+See setup guides: [Matrix](docs/MATRIX_SETUP.md) | [Slack](docs/SLACK_SETUP.md) | [Mattermost](docs/MATTERMOST_SETUP.md) | [WhatsApp](docs/WHATSAPP_SETUP.md) | [Discord](docs/DISCORD_SETUP.md) | [Telegram](docs/TELEGRAM_SETUP.md) | [Web](docs/WEB_SETUP.md)
 
 ## Docker
 
@@ -94,6 +100,7 @@ docker pull lbecchi/opencode-chat-bridge
 docker run -e CONNECTOR=discord -e DISCORD_TOKEN=your_token lbecchi/opencode-chat-bridge
 docker run -e CONNECTOR=slack -e SLACK_BOT_TOKEN=xoxb-... -e SLACK_APP_TOKEN=xapp-... lbecchi/opencode-chat-bridge
 docker run -e CONNECTOR=matrix -e MATRIX_HOMESERVER=https://matrix.org -e MATRIX_USER_ID=@bot:matrix.org -e MATRIX_PASSWORD=... lbecchi/opencode-chat-bridge
+docker run -e CONNECTOR=telegram -e TELEGRAM_BOT_TOKEN=110201543:AAH... lbecchi/opencode-chat-bridge
 ```
 
 Or use docker-compose:
@@ -225,6 +232,7 @@ opencode-chat-bridge/
     mattermost.ts
     matrix.ts
     slack.ts
+    telegram.ts
     whatsapp.ts
     web.ts
     web-widget.js      # Embeddable client-side widget
@@ -267,7 +275,9 @@ Setup guides:
 - [Slack](docs/SLACK_SETUP.md)
 - [Mattermost](docs/MATTERMOST_SETUP.md)
 - [WhatsApp](docs/WHATSAPP_SETUP.md)
-- [Discord](docs/DISCORD_SETUP.md) | [Web](docs/WEB_SETUP.md)
+- [Discord](docs/DISCORD_SETUP.md)
+- [Telegram](docs/TELEGRAM_SETUP.md)
+- [Web](docs/WEB_SETUP.md)
 
 Reference:
 - [Configuration](docs/CONFIGURATION.md)

--- a/config.example.json
+++ b/config.example.json
@@ -44,7 +44,17 @@
     "enabled": false,
     "token": "{env:DISCORD_TOKEN}"
   },
-  
+
+  "telegram": {
+    "enabled": false,
+    "token": "{env:TELEGRAM_BOT_TOKEN}",
+    "respondToMentions": true,
+    "threadIsolation": true,
+    "ignoreChats": [],
+    "ignoreUsers": [],
+    "allowedUsers": []
+  },
+
   "irc": {
     "enabled": false,
     "server": "irc.libera.chat",

--- a/connectors/telegram.ts
+++ b/connectors/telegram.ts
@@ -1,0 +1,920 @@
+#!/usr/bin/env bun
+/**
+ * Telegram Connector for OpenCode Chat Bridge
+ *
+ * Bridges Telegram chats to OpenCode via ACP protocol.
+ * Uses the Telegram Bot API (HTTP) via native fetch + long-polling
+ * (`getUpdates`). Zero external runtime dependencies.
+ *
+ * Thread Isolation (configurable via chat-bridge.json telegram.threadIsolation):
+ *   When enabled (default), sessions in forum supergroups are scoped per topic
+ *   using `${chatId}:${messageThreadId}`. Each topic gets its own isolated
+ *   OpenCode session and replies are posted inside the topic.
+ *   In non-forum chats, sessions are keyed on `chatId` only (one session per
+ *   chat), so a group and a DM with the same user share a session only if
+ *   they share a chat id (which they don't).
+ *
+ * Usage:
+ *   bun connectors/telegram.ts
+ *
+ * Environment variables:
+ *   TELEGRAM_BOT_TOKEN    - Bot token from @BotFather (required)
+ *   TELEGRAM_ALLOWED_USERS - Optional CSV of Telegram user IDs allowed to use
+ *                            the bot; messages from others are silently dropped
+ *   TELEGRAM_TRIGGER      - Optional trigger override (default: !oc)
+ *   TELEGRAM_DROP_PENDING - If "1", drop backlogged updates on startup so the
+ *                            bot only sees new messages after launch
+ */
+
+import fs from "fs"
+import path from "path"
+import { ACPClient, type ActivityEvent, type ImageContent } from "../src"
+import { getConfig } from "../src/config"
+import {
+  BaseConnector,
+  CommandHandler,
+  type BaseSession,
+  parseCsvList,
+  extractImagePaths,
+  extractDocPaths,
+  removeImageMarkers,
+  removeDocMarkers,
+  sanitizeServerPaths,
+} from "../src"
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+const config = getConfig()
+const TG_TOKEN = process.env.TELEGRAM_BOT_TOKEN || ""
+const TRIGGER = process.env.TELEGRAM_TRIGGER || config.trigger
+const BOT_NAME = config.botName
+const RATE_LIMIT_SECONDS = config.rateLimitSeconds
+const SESSION_RETENTION_DAYS = parseInt(process.env.SESSION_RETENTION_DAYS || "7", 10)
+const THREAD_ISOLATION = config.telegram.threadIsolation
+const DROP_PENDING = process.env.TELEGRAM_DROP_PENDING === "1"
+const ENV_ALLOWED_USERS = parseCsvList(process.env.TELEGRAM_ALLOWED_USERS)
+const ALLOWED_USERS = ENV_ALLOWED_USERS.length > 0 ? ENV_ALLOWED_USERS : config.telegram.allowedUsers
+
+const TG_API_BASE = `https://api.telegram.org/bot${TG_TOKEN}`
+const POLL_TIMEOUT_SECS = 30
+const MAX_MESSAGE_LENGTH = 4096
+
+// =============================================================================
+// Telegram Bot API helpers
+// =============================================================================
+
+interface TelegramApiResponse<T> {
+  ok: boolean
+  result?: T
+  description?: string
+  error_code?: number
+  parameters?: { retry_after?: number }
+}
+
+class TelegramApiError extends Error {
+  status?: number
+  retryAfter?: number
+  constructor(message: string, status?: number, retryAfter?: number) {
+    super(message)
+    this.name = "TelegramApiError"
+    this.status = status
+    this.retryAfter = retryAfter
+  }
+}
+
+/**
+ * Issue a JSON POST to the Telegram Bot API. Throws TelegramApiError on
+ * non-OK responses. Adds no runtime dependencies.
+ */
+async function tgApi<T = unknown>(method: string, body: Record<string, unknown> = {}): Promise<T> {
+  const url = `${TG_API_BASE}/${method}`
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+  // Network-level failure
+  if (!res.ok) {
+    const text = await res.text().catch(() => "")
+    throw new TelegramApiError(`Telegram API ${method} HTTP ${res.status}: ${text.slice(0, 200)}`, res.status)
+  }
+
+  // JSON parse errors are surfaced as exceptions from .json()
+  const json = (await res.json()) as TelegramApiResponse<T>
+  if (!json.ok) {
+    throw new TelegramApiError(
+      json.description || `Telegram API ${method} failed`,
+      json.error_code,
+      json.parameters?.retry_after
+    )
+  }
+  return json.result as T
+}
+
+/**
+ * Multipart upload for files (photo / document).
+ */
+async function tgUpload<T = unknown>(
+  method: string,
+  fields: Record<string, string>,
+  filePath: string,
+  fileField: string
+): Promise<T> {
+  const url = `${TG_API_BASE}/${method}`
+  const form = new FormData()
+  for (const [k, v] of Object.entries(fields)) {
+    form.append(k, v)
+  }
+  const buffer = fs.readFileSync(filePath)
+  form.append(fileField, new Blob([buffer]), path.basename(filePath))
+
+  const res = await fetch(url, { method: "POST", body: form })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "")
+    throw new TelegramApiError(`Telegram upload ${method} HTTP ${res.status}: ${text.slice(0, 200)}`, res.status)
+  }
+  const json = (await res.json()) as TelegramApiResponse<T>
+  if (!json.ok) {
+    throw new TelegramApiError(json.description || `Telegram upload ${method} failed`, json.error_code)
+  }
+  return json.result as T
+}
+
+// =============================================================================
+// Telegram event context helpers (pure, exported for testing)
+// =============================================================================
+
+/**
+ * Normalised context extracted from a Telegram update. Plain data only,
+ * no platform object references, so tests can construct it freely.
+ */
+export interface TelegramEventContext {
+  /** Telegram chat.id (positive integer or negative for groups), stringified */
+  chatId: string
+  /** Telegram from.id (always positive integer for real users), stringified */
+  userId: string
+  /** Telegram message_id used for reply_to_message_id */
+  messageId: number
+  /** Trimmed message text (or caption), empty string if absent */
+  text: string
+  /** message_thread_id when is_topic_message === true, null otherwise */
+  messageThreadId: number | null
+  /** message_id of the parent (when this is a reply), null otherwise */
+  replyToMessageId: number | null
+  /** One of: "private" | "group" | "supergroup" | "channel" */
+  chatType: string
+  /** True only for messages inside a forum supergroup topic */
+  isForumTopic: boolean
+  /** True for direct messages with the bot */
+  isPrivate: boolean
+  /** Session key -- chatId, or chatId:messageThreadId when threadIsolation applies */
+  sessionId: string
+  /** Idempotency key -- chatId:messageId */
+  dedupeId: string
+}
+
+/** Input shape for normalising a Telegram message. */
+export interface TelegramNormalizeInput {
+  chat: { id: number | string; type: string; is_forum?: boolean }
+  from: { id: number | string; is_bot?: boolean; username?: string; first_name?: string }
+  messageId: number
+  text?: string
+  is_topic_message?: boolean
+  message_thread_id?: number
+  reply_to_message?: { message_id: number }
+}
+
+/**
+ * Resolve the forum topic thread id.
+ * Only meaningful when the chat has topics enabled AND the message was posted
+ * as a topic message -- otherwise Telegram leaves message_thread_id unset.
+ */
+export function resolveMessageThreadId(input: {
+  is_topic_message?: boolean
+  message_thread_id?: number
+}): number | null {
+  if (input.is_topic_message && typeof input.message_thread_id === "number") {
+    return input.message_thread_id
+  }
+  return null
+}
+
+/**
+ * Build the session key. When threadIsolation is enabled AND we're inside a
+ * forum topic, key on `${chatId}:${messageThreadId}` so each topic gets its
+ * own isolated OpenCode session. Otherwise, key on chatId only.
+ */
+export function buildTelegramSessionId(
+  chatId: string,
+  messageThreadId: number | null,
+  threadIsolation: boolean
+): string {
+  if (threadIsolation && messageThreadId !== null) {
+    return `${chatId}:${messageThreadId}`
+  }
+  return chatId
+}
+
+/**
+ * Pure function -- turn a raw Telegram message payload into a
+ * TelegramEventContext. Exported for unit and integration tests.
+ */
+export function normalizeTelegramEventContext(
+  input: TelegramNormalizeInput,
+  threadIsolation: boolean
+): TelegramEventContext {
+  const chatId = String(input.chat.id)
+  const userId = String(input.from.id)
+  const messageThreadId = resolveMessageThreadId(input)
+  const text = (input.text || "").trim()
+  const replyToMessageId = input.reply_to_message?.message_id ?? null
+  const isForumTopic = Boolean(input.chat.is_forum) && Boolean(input.is_topic_message)
+
+  return {
+    chatId,
+    userId,
+    messageId: input.messageId,
+    text,
+    messageThreadId,
+    replyToMessageId,
+    chatType: input.chat.type,
+    isForumTopic,
+    isPrivate: input.chat.type === "private",
+    sessionId: buildTelegramSessionId(chatId, messageThreadId, threadIsolation),
+    dedupeId: `${chatId}:${input.messageId}`,
+  }
+}
+
+/**
+ * Decide whether a plain message inside a topic (no trigger, no @mention) should
+ * still be forwarded, because we already have an active session for that topic.
+ *
+ * The caller still has to verify an active session exists for the
+ * context.sessionId; this only decides eligibility.
+ */
+export function shouldHandleImplicitTopicReply(input: {
+  text: string
+  isPrivate: boolean
+  messageThreadId: number | null
+  trigger: string
+  botUsername?: string
+}): boolean {
+  if (!input.text) return false
+  if (input.isPrivate) return false
+  if (input.messageThreadId === null) return false
+  const lower = input.text.toLowerCase()
+  const triggerLower = input.trigger.toLowerCase()
+  if (lower.startsWith(`${triggerLower} `)) return false
+  if (lower === triggerLower) return false
+  if (input.botUsername) {
+    const mentionLower = `@${input.botUsername.toLowerCase()}`
+    if (lower.startsWith(`${mentionLower} `)) return false
+    if (lower === mentionLower) return false
+  }
+  return true
+}
+
+// =============================================================================
+// Session type
+// =============================================================================
+
+interface ChatSession extends BaseSession {}
+
+// =============================================================================
+// Telegram Connector
+// =============================================================================
+
+export class TelegramConnector extends BaseConnector<ChatSession> {
+  private botId = 0
+  private botUsername = ""
+  private offset = 0
+  private polling = false
+  private pollAbort: AbortController | null = null
+  private reconnectAttempts = 0
+  private maxReconnectAttempts = 20
+  private threadIsolation: boolean
+  private respondToMentions: boolean
+
+  constructor() {
+    super({
+      connector: "telegram",
+      trigger: TRIGGER,
+      botName: BOT_NAME,
+      rateLimitSeconds: RATE_LIMIT_SECONDS,
+      sessionRetentionDays: SESSION_RETENTION_DAYS,
+      allowedUsers: ALLOWED_USERS,
+    })
+    this.threadIsolation = THREAD_ISOLATION
+    this.respondToMentions = config.telegram.respondToMentions
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (!TG_TOKEN) {
+      console.error("Error: TELEGRAM_BOT_TOKEN not set")
+      console.error("Create a bot via @BotFather in Telegram and copy the token")
+      process.exit(1)
+    }
+
+    this.log("Starting...")
+    this.logStartup()
+    console.log(`  Thread isolation: ${this.threadIsolation ? "on (per-topic sessions)" : "off (per-chat sessions)"}`)
+    console.log(`  Respond to mentions: ${this.respondToMentions ? "on" : "off"}`)
+    if (DROP_PENDING) console.log(`  Will drop pending updates on startup`)
+
+    await this.cleanupSessions()
+
+    // Authenticate
+    let me: { id: number; username?: string; first_name: string }
+    try {
+      me = await tgApi<{ id: number; username?: string; first_name: string }>("getMe")
+    } catch (err) {
+      this.logError("Failed to authenticate with Telegram (check TELEGRAM_BOT_TOKEN):", err)
+      process.exit(1)
+    }
+    this.botId = me.id
+    this.botUsername = me.username || me.first_name || "bot"
+    console.log(`  Bot: @${this.botUsername} (id=${this.botId})`)
+
+    // Clear any conflicting webhook so getUpdates is the source of truth
+    try {
+      await tgApi("deleteWebhook", { drop_pending_updates: DROP_PENDING })
+      console.log(`  Webhook cleared${DROP_PENDING ? " (dropped pending updates)" : ""}`)
+    } catch (err) {
+      this.logError("Failed to clear webhook (continuing):", err)
+    }
+
+    // If asked to drop backlog, consume one batch with timeout=0 and advance
+    // the offset so the very next call skips already-queued messages.
+    if (DROP_PENDING) {
+      try {
+        const updates = await tgApi<Array<{ update_id: number }>>("getUpdates", {
+          timeout: 0,
+          allowed_updates: ["message", "edited_message"],
+        })
+        if (updates.length > 0) {
+          this.offset = Math.max(...updates.map((u) => u.update_id)) + 1
+          console.log(`  Dropped ${updates.length} pending update(s); offset=${this.offset}`)
+        }
+      } catch (err) {
+        this.logError("Failed to drop pending updates (continuing):", err)
+      }
+    }
+
+    this.polling = true
+    // Run polling in the background; don't await here
+    this.pollLoop().catch((err) => this.logError("Polling loop crashed:", err))
+    this.startSessionExpiryLoop()
+    this.log("Started! Listening for messages...")
+  }
+
+  async stop(): Promise<void> {
+    this.log("Stopping...")
+    this.polling = false
+    if (this.pollAbort) {
+      this.pollAbort.abort()
+      this.pollAbort = null
+    }
+    await this.disconnectAllSessions()
+    this.log("Stopped.")
+  }
+
+  /**
+   * Required by BaseConnector. Sends a plain text message to a chat.
+   * For the common case inside handleUpdate / processQuery we use
+   * sendReply() instead, which can also pin to a forum topic or reply
+   * to the originating message.
+   */
+  async sendMessage(chatId: string, text: string): Promise<void> {
+    const chunks = this.splitMessage(text, MAX_MESSAGE_LENGTH)
+    for (const chunk of chunks) {
+      try {
+        await tgApi("sendMessage", { chat_id: chatId, text: chunk })
+      } catch (err) {
+        this.logError(`Failed to send message to ${chatId}:`, err)
+      }
+    }
+  }
+
+  /**
+   * Send a reply, pinning to the originating forum topic or replying to the
+   * originating message when applicable. Mirrors Mattermost's `sendReply()`.
+   */
+  private async sendReply(context: TelegramEventContext, text: string): Promise<void> {
+    const chunks = this.splitMessage(text, MAX_MESSAGE_LENGTH)
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]
+      // The first chunk keeps the reply/reference; later chunks are plain
+      const body: Record<string, unknown> = { chat_id: context.chatId, text: chunk }
+      if (this.threadIsolation && context.messageThreadId !== null) {
+        body.message_thread_id = context.messageThreadId
+      } else if (i === 0 && context.replyToMessageId !== null && !context.isPrivate) {
+        body.reply_to_message_id = context.replyToMessageId
+        // reply_to_message_id is not allowed in forum topics; also drop it
+        // when threading otherwise.
+      }
+      try {
+        await tgApi("sendMessage", body)
+      } catch (err) {
+        this.logError(`Failed to send reply to ${context.sessionId}:`, err)
+        // In some topics reply_to_message_id is rejected; retry without it.
+        if (body.reply_to_message_id) {
+          const retry: Record<string, unknown> = { ...body }
+          delete retry.reply_to_message_id
+          try {
+            await tgApi("sendMessage", retry)
+          } catch (err2) {
+            this.logError(`Retry without reply_to_message_id also failed:`, err2)
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Long polling
+  // ---------------------------------------------------------------------------
+
+  private async pollLoop(): Promise<void> {
+    while (this.polling) {
+      this.pollAbort = new AbortController()
+      try {
+        await this.pollOnce(this.pollAbort.signal)
+        this.reconnectAttempts = 0
+      } catch (err: any) {
+        if (err?.name === "AbortError") return
+        this.reconnectAttempts++
+        // Honour retry_after for 429 too
+        let delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000)
+        if (typeof err?.retryAfter === "number") delay = Math.max(delay, err.retryAfter * 1000)
+        this.logError(
+          `Poll error (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts}); retrying in ${delay}ms:`,
+          err?.message || err
+        )
+        if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+          this.logError("Max reconnect attempts reached, exiting")
+          process.exit(1)
+        }
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      } finally {
+        this.pollAbort = null
+      }
+    }
+  }
+
+  private async pollOnce(signal: AbortSignal): Promise<void> {
+    const body: Record<string, unknown> = {
+      timeout: POLL_TIMEOUT_SECS,
+      allowed_updates: ["message", "edited_message"],
+    }
+    if (this.offset) body.offset = this.offset
+
+    const res = await fetch(`${TG_API_BASE}/getUpdates`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      throw new TelegramApiError(
+        `Telegram getUpdates HTTP ${res.status}: ${text.slice(0, 200)}`,
+        res.status
+      )
+    }
+    const json = (await res.json()) as TelegramApiResponse<Array<Record<string, unknown>>>
+    if (!json.ok) {
+      throw new TelegramApiError(
+        json.description || "getUpdates failed",
+        json.error_code,
+        json.parameters?.retry_after
+      )
+    }
+
+    const updates = json.result || []
+    for (const update of updates) {
+      // Advance offset monotonically
+      const id = (update as { update_id?: number }).update_id
+      if (typeof id === "number" && id + 1 > this.offset) {
+        this.offset = id + 1
+      }
+      try {
+        await this.handleUpdate(update)
+      } catch (err) {
+        this.logError("Error processing update:", err)
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handling
+  // ---------------------------------------------------------------------------
+
+  private async handleUpdate(update: Record<string, unknown>): Promise<void> {
+    const message = (update.message || update.edited_message) as
+      | Record<string, unknown>
+      | undefined
+    if (!message) return
+
+    // Skip bot-authored messages (defensive -- getUpdates typically does not
+    // echo back our own messages, but other bots in the chat will deliver)
+    const from = (message.from as Record<string, unknown> | undefined) || {}
+    if (from.is_bot === true) return
+
+    const chat = (message.chat as Record<string, unknown> | undefined)
+    if (!chat || chat.id === undefined) return
+
+    const ctx = normalizeTelegramEventContext(
+      {
+        chat: chat as { id: number | string; type: string; is_forum?: boolean },
+        from: from as { id: number | string; is_bot?: boolean; username?: string; first_name?: string },
+        messageId: Number(message.message_id),
+        text: String(message.text || message.caption || ""),
+        is_topic_message: message.is_topic_message as boolean | undefined,
+        message_thread_id: message.message_thread_id as number | undefined,
+        reply_to_message: message.reply_to_message as { message_id: number } | undefined,
+      },
+      this.threadIsolation
+    )
+
+    if (!ctx.text) return
+
+    // Dedupe (getUpdates occasionally replays at the same offset)
+    if (this.isDuplicateEvent(ctx.dedupeId)) return
+
+    // Allowlist + ignore lists
+    if (!this.isUserAllowed(ctx.userId)) return
+    const ignoreChats = config.telegram.ignoreChats || []
+    const ignoreUsers = config.telegram.ignoreUsers || []
+    if (ignoreChats.includes(ctx.chatId) || ignoreChats.includes(ctx.userId)) return
+    if (ignoreUsers.includes(ctx.userId)) return
+
+    const senderName =
+      [from.first_name, from.username].filter(Boolean).join("@") ||
+      String(from.id || ctx.userId)
+    this.log(`[MSG] ${senderName} in ${ctx.sessionId}: ${ctx.text}`)
+
+    // Resolve the query based on trigger / mention / DM / implicit topic reply
+    const mention = `@${this.botUsername}`
+    const text = ctx.text
+    let query = ""
+
+    if (text.startsWith(TRIGGER + " ")) {
+      query = text.slice(TRIGGER.length + 1).trim()
+    } else if (text === TRIGGER) {
+      query = ""
+    } else if (text.startsWith(TRIGGER)) {
+      query = text.slice(TRIGGER.length).trim()
+    } else if (
+      this.respondToMentions &&
+      text.startsWith(mention + " ")
+    ) {
+      query = text.slice(mention.length + 1).trim()
+    } else if (this.respondToMentions && text === mention) {
+      query = ""
+    } else if (this.respondToMentions && text.startsWith(mention)) {
+      query = text.slice(mention.length).trim()
+    } else if (ctx.isPrivate) {
+      query = text
+    } else if (
+      this.threadIsolation &&
+      shouldHandleImplicitTopicReply({
+        text,
+        isPrivate: false,
+        messageThreadId: ctx.messageThreadId,
+        trigger: TRIGGER,
+        botUsername: this.botUsername,
+      }) &&
+      this.sessionManager.has(ctx.sessionId)
+    ) {
+      // Implicit follow-up inside an active topic
+      query = text
+    } else {
+      return
+    }
+
+    // Bridge-local commands
+    if (query.startsWith("/")) {
+      const cmdName = query.slice(1).split(" ")[0].toLowerCase()
+      if (["status", "clear", "reset", "help"].includes(cmdName)) {
+        const session = this.sessionManager.get(ctx.sessionId)
+        const openCodeCommands = session?.client.availableCommands || []
+        await this.handleCommand(
+          ctx.sessionId,
+          query,
+          async (txt) => {
+            await this.sendReply(ctx, txt)
+          },
+          { openCodeCommands }
+        )
+        return
+      }
+
+      // Forward other /commands to OpenCode
+      this.log(`[CMD] Forwarding to OpenCode: ${query}`)
+      if (!this.checkRateLimit(ctx.userId)) return
+      await this.processQuery(ctx, query)
+      return
+    }
+
+    // If user just pinged with no query, give a hint instead of consuming
+    // a query slot.
+    if (!query) {
+      if (!ctx.isPrivate) {
+        await this.sendReply(
+          ctx,
+          `Hello! Use \`${TRIGGER}\` to ask me anything, e.g. \`${TRIGGER} what's the weather?\``
+        )
+      }
+      return
+    }
+
+    if (!this.checkRateLimit(ctx.userId)) return
+    this.log(`[QUERY] ${ctx.sessionId}: ${query}`)
+    await this.processQuery(ctx, query)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Query processing
+  // ---------------------------------------------------------------------------
+
+  private async processQuery(context: TelegramEventContext, query: string): Promise<void> {
+    const startTime = Date.now()
+
+    // Best-effort typing indicator (do not await; ignore failures)
+    this.sendChatAction(context, "typing").catch(() => {})
+
+    // Guard against concurrent queries on the same session
+    if (this.isQueryActive(context.sessionId)) {
+      await this.sendReply(context, "A request is already running. Please wait for it to finish.")
+      return
+    }
+    this.markQueryActive(context.sessionId)
+
+    const session = await this.getOrCreateSession(context.sessionId, (client) =>
+      this.createSession(client)
+    )
+    if (!session) {
+      await this.sendReply(context, CommandHandler.formatConnectionErrorMessage())
+      return
+    }
+
+    session.messageCount++
+    session.lastActivity = new Date()
+    session.inputChars += query.length
+
+    const client = session.client
+
+    let responseBuffer = ""
+    let toolResultsBuffer = ""
+    let lastActivityMessage = ""
+    let toolCallCount = 0
+    const sentToolOutputs = new Set<string>()
+
+    const activityHandler = async (activity: ActivityEvent) => {
+      if (activity.type === "tool_start") {
+        toolCallCount++
+        if (activity.message !== lastActivityMessage) {
+          lastActivityMessage = activity.message
+          await this.sendReply(context, `> ${activity.message}`)
+        }
+      }
+    }
+    const chunkHandler = (text: string) => {
+      responseBuffer += text
+    }
+    const updateHandler = async (update: any) => {
+      if (update.type === "tool_result" && update.toolResult) {
+        toolResultsBuffer += update.toolResult
+
+        const toolName = update.toolName || ""
+        const streamTools = config.streamTools || ["bash"]
+        const shouldShow = streamTools.some((t: string) => toolName.includes(t))
+        if (!shouldShow) return
+
+        const maxLen = 2000
+        const result =
+          update.toolResult.length > maxLen
+            ? update.toolResult.slice(0, maxLen) + "\n... (truncated)"
+            : update.toolResult
+        const trimmed = result.trim()
+        if (!trimmed) return
+
+        const hash = trimmed.slice(0, 100)
+        if (sentToolOutputs.has(hash)) return
+        sentToolOutputs.add(hash)
+        try {
+          await this.sendReply(context, trimmed)
+        } catch (err) {
+          this.log(`[RESULT] Error sending: ${err}`)
+        }
+      }
+
+      // Stream partial tool output
+      if (update.type === "tool_output_delta" && update.partialOutput) {
+        const toolName = update.toolName || ""
+        const streamTools = config.streamTools || ["bash"]
+        const shouldStream = streamTools.some((t: string) => toolName.includes(t))
+        if (!shouldStream) return
+
+        const output = update.partialOutput.trim()
+        if (!output) return
+        const hash = output.slice(0, 100)
+        if (sentToolOutputs.has(hash)) return
+        sentToolOutputs.add(hash)
+        await this.sendReply(context, output)
+        this.log(`[STREAM] Sent ${toolName} output (${output.length} chars)`)
+      }
+    }
+    const imageHandler = async (image: ImageContent) => {
+      this.log(`Received image: ${image.mimeType}`)
+    }
+    const permissionHandler = async (event: {
+      permission: string
+      path: string | null
+      message: string
+    }) => {
+      this.log(`[PERMISSION] Rejected: ${event.permission}${event.path ? ` (${event.path})` : ""}`)
+      await this.sendReply(context, `> ${event.message}`)
+    }
+
+    client.on("activity", activityHandler)
+    client.on("chunk", chunkHandler)
+    client.on("update", updateHandler)
+    client.on("image", imageHandler)
+    client.on("permission_rejected", permissionHandler)
+
+    try {
+      await client.prompt(query)
+
+      // Images from tool results (primary)
+      const uploadedPaths = new Set<string>()
+      const toolImagePaths = extractImagePaths(toolResultsBuffer)
+      for (const imagePath of toolImagePaths) {
+        if (fs.existsSync(imagePath)) {
+          this.log(`Uploading image from tool result: ${imagePath}`)
+          await this.sendPhotoFromFile(context, imagePath)
+          uploadedPaths.add(imagePath)
+        }
+      }
+      // Images echoed in the response
+      const responseImagePaths = extractImagePaths(responseBuffer)
+      for (const imagePath of responseImagePaths) {
+        if (uploadedPaths.has(imagePath)) continue
+        if (fs.existsSync(imagePath)) {
+          this.log(`Uploading image from response: ${imagePath}`)
+          await this.sendPhotoFromFile(context, imagePath)
+        }
+      }
+
+      // Documents from tool results
+      const uploadedDocs = new Set<string>()
+      const toolDocPaths = extractDocPaths(toolResultsBuffer)
+      for (const docPath of toolDocPaths) {
+        if (fs.existsSync(docPath)) {
+          this.log(`Uploading document from tool result: ${docPath}`)
+          await this.sendDocumentFromFile(context, docPath)
+          uploadedDocs.add(docPath)
+        }
+      }
+      // Documents echoed in the response
+      const responseDocPaths = extractDocPaths(responseBuffer)
+      for (const docPath of responseDocPaths) {
+        if (uploadedDocs.has(docPath)) continue
+        if (fs.existsSync(docPath)) {
+          this.log(`Uploading document from response: ${docPath}`)
+          await this.sendDocumentFromFile(context, docPath)
+        }
+      }
+
+      // Final cleaned response
+      const cleanResponse = sanitizeServerPaths(
+        removeDocMarkers(removeImageMarkers(responseBuffer))
+      )
+      if (cleanResponse) {
+        session.outputChars += cleanResponse.length
+        await this.sendReply(context, cleanResponse)
+      }
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+      const outChars = cleanResponse ? cleanResponse.length : 0
+      const tools = toolCallCount > 0 ? `, ${toolCallCount} tool${toolCallCount > 1 ? "s" : ""}` : ""
+      this.log(`[DONE] ${elapsed}s (${outChars} chars${tools}) [${context.sessionId}]`)
+    } catch (err) {
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+      this.logError(`[FAIL] ${elapsed}s [${context.sessionId}]:`, err)
+      await this.sendReply(context, CommandHandler.formatProcessingErrorMessage())
+    } finally {
+      client.off("activity", activityHandler)
+      client.off("chunk", chunkHandler)
+      client.off("update", updateHandler)
+      client.off("image", imageHandler)
+      client.off("permission_rejected", permissionHandler)
+      if (session) session.lastActivity = new Date()
+      this.markQueryDone(context.sessionId)
+    }
+  }
+
+  private createSession(client: ACPClient): ChatSession {
+    return { ...this.createBaseSession(client) }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Media uploads
+  // ---------------------------------------------------------------------------
+
+  private async sendPhotoFromFile(context: TelegramEventContext, filePath: string): Promise<void> {
+    try {
+      if (!fs.existsSync(filePath)) {
+        this.logError(`Image not found: ${filePath}`)
+        return
+      }
+      const fields: Record<string, string> = { chat_id: context.chatId }
+      if (this.threadIsolation && context.messageThreadId !== null) {
+        fields.message_thread_id = String(context.messageThreadId)
+      }
+      await tgUpload("sendPhoto", fields, filePath, "photo")
+      this.log(`Sent photo to ${context.sessionId}: ${path.basename(filePath)}`)
+    } catch (err) {
+      this.logError(`Failed to send photo to ${context.sessionId}:`, err)
+    }
+  }
+
+  private async sendDocumentFromFile(context: TelegramEventContext, filePath: string): Promise<void> {
+    try {
+      if (!fs.existsSync(filePath)) {
+        this.logError(`Document not found: ${filePath}`)
+        return
+      }
+      const fields: Record<string, string> = { chat_id: context.chatId }
+      if (this.threadIsolation && context.messageThreadId !== null) {
+        fields.message_thread_id = String(context.messageThreadId)
+      }
+      await tgUpload("sendDocument", fields, filePath, "document")
+      this.log(`Sent document to ${context.sessionId}: ${path.basename(filePath)}`)
+    } catch (err) {
+      this.logError(`Failed to send document to ${context.sessionId}:`, err)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Chat actions / helpers
+  // ---------------------------------------------------------------------------
+
+  private async sendChatAction(context: TelegramEventContext, action: string): Promise<void> {
+    try {
+      const body: Record<string, unknown> = { chat_id: context.chatId, action }
+      if (this.threadIsolation && context.messageThreadId !== null) {
+        body.message_thread_id = context.messageThreadId
+      }
+      await tgApi("sendChatAction", body)
+    } catch {
+      // typing indicator is best-effort
+    }
+  }
+
+  private splitMessage(text: string, maxLen: number): string[] {
+    const chunks: string[] = []
+    let remaining = text
+    while (remaining.length > maxLen) {
+      let splitAt = remaining.lastIndexOf("\n", maxLen)
+      if (splitAt <= 0) splitAt = maxLen
+      chunks.push(remaining.slice(0, splitAt))
+      remaining = remaining.slice(splitAt).trimStart()
+    }
+    if (remaining) chunks.push(remaining)
+    return chunks
+  }
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main() {
+  const connector = new TelegramConnector()
+  process.on("SIGINT", async () => {
+    await connector.stop()
+    process.exit(0)
+  })
+  process.on("SIGTERM", async () => {
+    await connector.stop()
+    process.exit(0)
+  })
+  await connector.start()
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("Fatal error:", err)
+    process.exit(1)
+  })
+}

--- a/connectors/telegram.ts
+++ b/connectors/telegram.ts
@@ -47,7 +47,7 @@ import {
 // =============================================================================
 
 const config = getConfig()
-const TG_TOKEN = process.env.TELEGRAM_BOT_TOKEN || ""
+const TG_TOKEN = process.env.TELEGRAM_BOT_TOKEN || config.telegram.token || ""
 const TRIGGER = process.env.TELEGRAM_TRIGGER || config.trigger
 const BOT_NAME = config.botName
 const RATE_LIMIT_SECONDS = config.rateLimitSeconds
@@ -406,6 +406,11 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
   /**
    * Send a reply, pinning to the originating forum topic or replying to the
    * originating message when applicable. Mirrors Mattermost's `sendReply()`.
+   *
+   * Note: replies are always posted inside the topic the user wrote from
+   * (when messageThreadId is set), regardless of `threadIsolation`. That
+   * setting only controls SESSION keying -- reply routing is independent
+   * because Telegram users expect responses where they asked.
    */
   private async sendReply(context: TelegramEventContext, text: string): Promise<void> {
     const chunks = this.splitMessage(text, MAX_MESSAGE_LENGTH)
@@ -413,12 +418,13 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
       const chunk = chunks[i]
       // The first chunk keeps the reply/reference; later chunks are plain
       const body: Record<string, unknown> = { chat_id: context.chatId, text: chunk }
-      if (this.threadIsolation && context.messageThreadId !== null) {
+      if (context.messageThreadId !== null) {
+        // Always pin to the originating topic -- otherwise the response
+        // would land in the supergroup's general chat root, which is
+        // surprising for users navigating a forum.
         body.message_thread_id = context.messageThreadId
       } else if (i === 0 && context.replyToMessageId !== null && !context.isPrivate) {
         body.reply_to_message_id = context.replyToMessageId
-        // reply_to_message_id is not allowed in forum topics; also drop it
-        // when threading otherwise.
       }
       try {
         await tgApi("sendMessage", body)
@@ -657,169 +663,179 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
       await this.sendReply(context, "A request is already running. Please wait for it to finish.")
       return
     }
-    this.markQueryActive(context.sessionId)
 
-    const session = await this.getOrCreateSession(context.sessionId, (client) =>
-      this.createSession(client)
-    )
-    if (!session) {
-      await this.sendReply(context, CommandHandler.formatConnectionErrorMessage())
-      return
-    }
-
-    session.messageCount++
-    session.lastActivity = new Date()
-    session.inputChars += query.length
-
-    const client = session.client
-
-    let responseBuffer = ""
-    let toolResultsBuffer = ""
-    let lastActivityMessage = ""
-    let toolCallCount = 0
-    const sentToolOutputs = new Set<string>()
-
-    const activityHandler = async (activity: ActivityEvent) => {
-      if (activity.type === "tool_start") {
-        toolCallCount++
-        if (activity.message !== lastActivityMessage) {
-          lastActivityMessage = activity.message
-          await this.sendReply(context, `> ${activity.message}`)
-        }
-      }
-    }
-    const chunkHandler = (text: string) => {
-      responseBuffer += text
-    }
-    const updateHandler = async (update: any) => {
-      if (update.type === "tool_result" && update.toolResult) {
-        toolResultsBuffer += update.toolResult
-
-        const toolName = update.toolName || ""
-        const streamTools = config.streamTools || ["bash"]
-        const shouldShow = streamTools.some((t: string) => toolName.includes(t))
-        if (!shouldShow) return
-
-        const maxLen = 2000
-        const result =
-          update.toolResult.length > maxLen
-            ? update.toolResult.slice(0, maxLen) + "\n... (truncated)"
-            : update.toolResult
-        const trimmed = result.trim()
-        if (!trimmed) return
-
-        const hash = trimmed.slice(0, 100)
-        if (sentToolOutputs.has(hash)) return
-        sentToolOutputs.add(hash)
-        try {
-          await this.sendReply(context, trimmed)
-        } catch (err) {
-          this.log(`[RESULT] Error sending: ${err}`)
-        }
-      }
-
-      // Stream partial tool output
-      if (update.type === "tool_output_delta" && update.partialOutput) {
-        const toolName = update.toolName || ""
-        const streamTools = config.streamTools || ["bash"]
-        const shouldStream = streamTools.some((t: string) => toolName.includes(t))
-        if (!shouldStream) return
-
-        const output = update.partialOutput.trim()
-        if (!output) return
-        const hash = output.slice(0, 100)
-        if (sentToolOutputs.has(hash)) return
-        sentToolOutputs.add(hash)
-        await this.sendReply(context, output)
-        this.log(`[STREAM] Sent ${toolName} output (${output.length} chars)`)
-      }
-    }
-    const imageHandler = async (image: ImageContent) => {
-      this.log(`Received image: ${image.mimeType}`)
-    }
-    const permissionHandler = async (event: {
-      permission: string
-      path: string | null
-      message: string
-    }) => {
-      this.log(`[PERMISSION] Rejected: ${event.permission}${event.path ? ` (${event.path})` : ""}`)
-      await this.sendReply(context, `> ${event.message}`)
-    }
-
-    client.on("activity", activityHandler)
-    client.on("chunk", chunkHandler)
-    client.on("update", updateHandler)
-    client.on("image", imageHandler)
-    client.on("permission_rejected", permissionHandler)
+    // Mark active and ensure the handle is cleared in `finally` so a
+    // session-creation failure cannot leave the session permanently
+    // reporting "A request is already running" until restart.
+    const activeQuery = this.markQueryActive(context.sessionId)
 
     try {
-      await client.prompt(query)
-
-      // Images from tool results (primary)
-      const uploadedPaths = new Set<string>()
-      const toolImagePaths = extractImagePaths(toolResultsBuffer)
-      for (const imagePath of toolImagePaths) {
-        if (fs.existsSync(imagePath)) {
-          this.log(`Uploading image from tool result: ${imagePath}`)
-          await this.sendPhotoFromFile(context, imagePath)
-          uploadedPaths.add(imagePath)
-        }
-      }
-      // Images echoed in the response
-      const responseImagePaths = extractImagePaths(responseBuffer)
-      for (const imagePath of responseImagePaths) {
-        if (uploadedPaths.has(imagePath)) continue
-        if (fs.existsSync(imagePath)) {
-          this.log(`Uploading image from response: ${imagePath}`)
-          await this.sendPhotoFromFile(context, imagePath)
-        }
-      }
-
-      // Documents from tool results
-      const uploadedDocs = new Set<string>()
-      const toolDocPaths = extractDocPaths(toolResultsBuffer)
-      for (const docPath of toolDocPaths) {
-        if (fs.existsSync(docPath)) {
-          this.log(`Uploading document from tool result: ${docPath}`)
-          await this.sendDocumentFromFile(context, docPath)
-          uploadedDocs.add(docPath)
-        }
-      }
-      // Documents echoed in the response
-      const responseDocPaths = extractDocPaths(responseBuffer)
-      for (const docPath of responseDocPaths) {
-        if (uploadedDocs.has(docPath)) continue
-        if (fs.existsSync(docPath)) {
-          this.log(`Uploading document from response: ${docPath}`)
-          await this.sendDocumentFromFile(context, docPath)
-        }
-      }
-
-      // Final cleaned response
-      const cleanResponse = sanitizeServerPaths(
-        removeDocMarkers(removeImageMarkers(responseBuffer))
+      const session = await this.getOrCreateSession(context.sessionId, (client) =>
+        this.createSession(client)
       )
-      if (cleanResponse) {
-        session.outputChars += cleanResponse.length
-        await this.sendReply(context, cleanResponse)
+      if (!session) {
+        await this.sendReply(context, CommandHandler.formatConnectionErrorMessage())
+        return
       }
 
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-      const outChars = cleanResponse ? cleanResponse.length : 0
-      const tools = toolCallCount > 0 ? `, ${toolCallCount} tool${toolCallCount > 1 ? "s" : ""}` : ""
-      this.log(`[DONE] ${elapsed}s (${outChars} chars${tools}) [${context.sessionId}]`)
-    } catch (err) {
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-      this.logError(`[FAIL] ${elapsed}s [${context.sessionId}]:`, err)
-      await this.sendReply(context, CommandHandler.formatProcessingErrorMessage())
+      session.messageCount++
+      session.lastActivity = new Date()
+      session.inputChars += query.length
+
+      const client = session.client
+
+      let responseBuffer = ""
+      let toolResultsBuffer = ""
+      let lastActivityMessage = ""
+      let toolCallCount = 0
+      const sentToolOutputs = new Set<string>()
+
+      const activityHandler = async (activity: ActivityEvent) => {
+        if (activity.type === "tool_start") {
+          toolCallCount++
+          if (activity.message !== lastActivityMessage) {
+            lastActivityMessage = activity.message
+            await this.sendReply(context, `> ${activity.message}`)
+          }
+        }
+      }
+      const chunkHandler = (text: string) => {
+        responseBuffer += text
+      }
+      const updateHandler = async (update: any) => {
+        if (update.type === "tool_result" && update.toolResult) {
+          toolResultsBuffer += update.toolResult
+
+          const toolName = update.toolName || ""
+          const streamTools = config.streamTools || ["bash"]
+          const shouldShow = streamTools.some((t: string) => toolName.includes(t))
+          if (!shouldShow) return
+
+          const maxLen = 2000
+          const result =
+            update.toolResult.length > maxLen
+              ? update.toolResult.slice(0, maxLen) + "\n... (truncated)"
+              : update.toolResult
+          const trimmed = result.trim()
+          if (!trimmed) return
+
+          const hash = trimmed.slice(0, 100)
+          if (sentToolOutputs.has(hash)) return
+          sentToolOutputs.add(hash)
+          try {
+            await this.sendReply(context, trimmed)
+          } catch (err) {
+            this.log(`[RESULT] Error sending: ${err}`)
+          }
+        }
+
+        // Stream partial tool output
+        if (update.type === "tool_output_delta" && update.partialOutput) {
+          const toolName = update.toolName || ""
+          const streamTools = config.streamTools || ["bash"]
+          const shouldStream = streamTools.some((t: string) => toolName.includes(t))
+          if (!shouldStream) return
+
+          const output = update.partialOutput.trim()
+          if (!output) return
+          const hash = output.slice(0, 100)
+          if (sentToolOutputs.has(hash)) return
+          sentToolOutputs.add(hash)
+          await this.sendReply(context, output)
+          this.log(`[STREAM] Sent ${toolName} output (${output.length} chars)`)
+        }
+      }
+      const imageHandler = async (image: ImageContent) => {
+        this.log(`Received image: ${image.mimeType}`)
+      }
+      const permissionHandler = async (event: {
+        permission: string
+        path: string | null
+        message: string
+      }) => {
+        this.log(`[PERMISSION] Rejected: ${event.permission}${event.path ? ` (${event.path})` : ""}`)
+        await this.sendReply(context, `> ${event.message}`)
+      }
+
+      client.on("activity", activityHandler)
+      client.on("chunk", chunkHandler)
+      client.on("update", updateHandler)
+      client.on("image", imageHandler)
+      client.on("permission_rejected", permissionHandler)
+
+      try {
+        await client.prompt(query)
+
+        // Images from tool results (primary)
+        const uploadedPaths = new Set<string>()
+        const toolImagePaths = extractImagePaths(toolResultsBuffer)
+        for (const imagePath of toolImagePaths) {
+          if (fs.existsSync(imagePath)) {
+            this.log(`Uploading image from tool result: ${imagePath}`)
+            await this.sendPhotoFromFile(context, imagePath)
+            uploadedPaths.add(imagePath)
+          }
+        }
+        // Images echoed in the response
+        const responseImagePaths = extractImagePaths(responseBuffer)
+        for (const imagePath of responseImagePaths) {
+          if (uploadedPaths.has(imagePath)) continue
+          if (fs.existsSync(imagePath)) {
+            this.log(`Uploading image from response: ${imagePath}`)
+            await this.sendPhotoFromFile(context, imagePath)
+          }
+        }
+
+        // Documents from tool results
+        const uploadedDocs = new Set<string>()
+        const toolDocPaths = extractDocPaths(toolResultsBuffer)
+        for (const docPath of toolDocPaths) {
+          if (fs.existsSync(docPath)) {
+            this.log(`Uploading document from tool result: ${docPath}`)
+            await this.sendDocumentFromFile(context, docPath)
+            uploadedDocs.add(docPath)
+          }
+        }
+        // Documents echoed in the response
+        const responseDocPaths = extractDocPaths(responseBuffer)
+        for (const docPath of responseDocPaths) {
+          if (uploadedDocs.has(docPath)) continue
+          if (fs.existsSync(docPath)) {
+            this.log(`Uploading document from response: ${docPath}`)
+            await this.sendDocumentFromFile(context, docPath)
+          }
+        }
+
+        // Final cleaned response
+        const cleanResponse = sanitizeServerPaths(
+          removeDocMarkers(removeImageMarkers(responseBuffer))
+        )
+        if (cleanResponse) {
+          session.outputChars += cleanResponse.length
+          await this.sendReply(context, cleanResponse)
+        }
+
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+        const outChars = cleanResponse ? cleanResponse.length : 0
+        const tools = toolCallCount > 0 ? `, ${toolCallCount} tool${toolCallCount > 1 ? "s" : ""}` : ""
+        this.log(`[DONE] ${elapsed}s (${outChars} chars${tools}) [${context.sessionId}]`)
+      } catch (err) {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+        this.logError(`[FAIL] ${elapsed}s [${context.sessionId}]:`, err)
+        await this.sendReply(context, CommandHandler.formatProcessingErrorMessage())
+      } finally {
+        client.off("activity", activityHandler)
+        client.off("chunk", chunkHandler)
+        client.off("update", updateHandler)
+        client.off("image", imageHandler)
+        client.off("permission_rejected", permissionHandler)
+        if (session) session.lastActivity = new Date()
+        // markQueryDone is intentionally not called here -- the outer
+        // finally below is the single source of truth so it always runs,
+        // even on session-creation failure.
+      }
     } finally {
-      client.off("activity", activityHandler)
-      client.off("chunk", chunkHandler)
-      client.off("update", updateHandler)
-      client.off("image", imageHandler)
-      client.off("permission_rejected", permissionHandler)
-      if (session) session.lastActivity = new Date()
-      this.markQueryDone(context.sessionId)
+      this.markQueryDone(context.sessionId, activeQuery)
     }
   }
 
@@ -838,7 +854,7 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
         return
       }
       const fields: Record<string, string> = { chat_id: context.chatId }
-      if (this.threadIsolation && context.messageThreadId !== null) {
+      if (context.messageThreadId !== null) {
         fields.message_thread_id = String(context.messageThreadId)
       }
       await tgUpload("sendPhoto", fields, filePath, "photo")
@@ -855,7 +871,7 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
         return
       }
       const fields: Record<string, string> = { chat_id: context.chatId }
-      if (this.threadIsolation && context.messageThreadId !== null) {
+      if (context.messageThreadId !== null) {
         fields.message_thread_id = String(context.messageThreadId)
       }
       await tgUpload("sendDocument", fields, filePath, "document")
@@ -872,7 +888,7 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
   private async sendChatAction(context: TelegramEventContext, action: string): Promise<void> {
     try {
       const body: Record<string, unknown> = { chat_id: context.chatId, action }
-      if (this.threadIsolation && context.messageThreadId !== null) {
+      if (context.messageThreadId !== null) {
         body.message_thread_id = context.messageThreadId
       }
       await tgApi("sendChatAction", body)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,13 @@ services:
       - MATTERMOST_TOKEN=${MATTERMOST_TOKEN}
       - MATTERMOST_TEAM=${MATTERMOST_TEAM:-}
 
+  telegram:
+    <<: *common
+    container_name: opencode-telegram
+    environment:
+      - CONNECTOR=telegram
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+
 volumes:
   sessions:
   whatsapp-auth:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,7 +35,11 @@ opencode-chat-bridge/
 ├── connectors/           # Chat platform connectors
 │   ├── matrix.ts
 │   ├── slack.ts
-│   └── whatsapp.ts
+│   ├── whatsapp.ts
+│   ├── mattermost.ts
+│   ├── discord.ts
+│   ├── telegram.ts
+│   └── web.ts
 ├── docs/                 # Documentation
 ├── opencode.json         # Agent and permission configuration
 └── tests/                # Test scripts
@@ -52,8 +56,11 @@ We have connectors for several chat platforms, with more planned:
 | Matrix | Done | - |
 | Slack | Done | - |
 | WhatsApp | Done | - |
+| Mattermost | Done | - |
+| Discord | Done | - |
+| Telegram | Done | - |
+| Web | Done | - |
 | IRC | Planned | Low |
-| Telegram | Planned | Low |
 
 ### 2. Documentation
 

--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -1,0 +1,342 @@
+# Telegram Setup Guide
+
+This guide walks you through setting up the Telegram connector for OpenCode Chat Bridge.
+
+## Overview
+
+The Telegram connector uses the public Telegram Bot API (HTTP) via long-polling
+(`getUpdates`). It does **not** require a public webhook or any incoming ports,
+so it works behind NAT, corporate firewalls, and on machines without a
+TLS-terminated domain.
+
+**How it works:**
+1. You create a bot via [@BotFather](https://t.me/BotFather) on Telegram
+2. You copy the bot token into your `.env` file
+3. The connector authenticates with `getMe`, then long-polls `getUpdates` for
+   incoming messages
+4. For each matching message, an isolated OpenCode session is created
+   (per chat, or per forum topic) and the response is streamed back to the
+   same chat
+
+The connector has **zero external runtime dependencies** -- it uses the native
+`fetch` API.
+
+## Step 1: Create the Bot
+
+1. Open Telegram and message [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts (give it a name and a unique
+   username ending in `bot`)
+3. BotFather replies with an HTTP API token like
+   `110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw`. Copy it.
+
+Optionally, send `/setprivacy` to BotFather and choose **Disable** so the bot
+can read all group messages (not just commands and mentions). This is required
+for the connector's per-topic follow-up behavior to work without re-mentioning
+the bot. The connector still respects `TELEGRAM_ALLOWED_USERS` and the
+`ignoreUsers` allowlist either way.
+
+## Step 2: Configure Environment
+
+Add to your `.env` file:
+
+```bash
+TELEGRAM_BOT_TOKEN=110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw
+
+# Optional: restrict to specific user IDs (comma-separated)
+# Find a user's ID by messaging them and checking @userinfobot or similar
+TELEGRAM_ALLOWED_USERS=123456789,987654321
+
+# Optional: drop messages that arrived while the bot was offline
+# (default: process backlog once on startup)
+# TELEGRAM_DROP_PENDING=1
+```
+
+If you prefer config-file-based setup (recommended for self-hosted
+installations), add to `chat-bridge.json`:
+
+```json
+{
+  "telegram": {
+    "enabled": true,
+    "token": "{env:TELEGRAM_BOT_TOKEN}",
+    "respondToMentions": true,
+    "threadIsolation": true,
+    "ignoreChats": [],
+    "ignoreUsers": [],
+    "allowedUsers": []
+  }
+}
+```
+
+All keys are optional except `enabled` and `token`. `respondToMentions` (default
+`true`) makes the bot also reply when you `@`-mention it in groups (in
+addition to the trigger prefix). `threadIsolation` (default `true`) gives each
+forum topic its own isolated OpenCode session.
+
+## Step 3: Run the Connector
+
+```bash
+bun connectors/telegram.ts
+```
+
+Expected output:
+
+```
+[TELEGRAM] Starting...
+  Trigger: !oc
+  Bot name: oc
+  Session storage: ~/.cache/opencode-chat-bridge/sessions
+  Thread isolation: on (per-topic sessions)
+  Respond to mentions: on
+[TELEGRAM] Cleaning up old sessions...
+  Bot: @your_bot (id=1234567890)
+  Webhook cleared
+[TELEGRAM] Started! Listening for messages...
+```
+
+## Step 4: Test the Bot
+
+Open a chat with your bot (in Telegram, search for the bot's @-username) and
+type:
+
+```
+!oc hello
+!oc what's the weather in Barcelona?
+!oc /help
+!oc /status
+!oc /clear
+```
+
+In a group with **Topics enabled** (a Telegram supergroup converted to a
+forum), open a topic and send `!oc hello` there. The bot replies inside that
+topic; subsequent plain replies in the topic continue that conversation until
+you send `/clear` or 30 minutes pass without activity.
+
+In groups **without** topics, prefix every message with `!oc` or `@botname` to
+trigger the bot.
+
+## Behavior Reference
+
+### Trigger prefix
+
+Default trigger is `!oc`. Override per-connector via `TELEGRAM_TRIGGER` or
+globally via `TRIGGER` in `chat-bridge.json`.
+
+A message becomes a query when:
+
+1. It starts with `${TRIGGER}` (e.g., `!oc summarize this`), or
+2. It `@`-mentions the bot (e.g., `@your_bot hello`), or
+3. It is sent to the bot in a private chat (auto-handled, no prefix needed), or
+4. It is a plain reply inside an active topic when `threadIsolation` is on
+   (the connector continues the conversation without re-mentioning)
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `!oc /status` | Show session info |
+| `!oc /clear` (or `/reset`) | Reset conversation session |
+| `!oc /help` | Show available commands |
+
+OpenCode-native commands (`/init`, `/compact`, `/review`, ...) are discovered
+via ACP and listed in `/help`. When invoked they are forwarded directly to
+OpenCode.
+
+### Per-topic vs per-chat sessions
+
+Telegram supergroups can be converted into **forums** with topics. Each topic
+is an independent sub-chat identified by `message_thread_id`.
+
+- `threadIsolation: true` (default): sessions are keyed on
+  `${chatId}:${messageThreadId}`. Each topic has its own conversation history.
+  Replies are posted inside the topic using Telegram's `message_thread_id`
+  parameter, so the bot's response stays grouped with the conversation.
+- `threadIsolation: false`: one session per `chatId`. All topics in the
+  supergroup share conversation history. Replies in groups use
+  `reply_to_message_id` for visual continuity; topics are still respected if
+  the original message was in one.
+
+### File uploads
+
+When OpenCode produces images or documents, the connector uploads them as
+native Telegram attachments via `sendPhoto` and `sendDocument`. Files produced
+during tool use (e.g., `bash` outputs, `[DOCLIBRARY_IMAGE]` /
+`[DOCLIBRARY_DOC]` markers) are sent automatically.
+
+Telegram limits: photos up to **10 MB** and 1024x1024 max dimension before
+recomputation; documents up to **50 MB**.
+
+### Long message splitting
+
+The Telegram Bot API caps `sendMessage` at **4096 characters**. The connector
+splits longer responses at newline boundaries and sends them as sequential
+messages. The first chunk keeps the `reply_to_message_id` reference (in groups)
+or the `message_thread_id` reference (in topics).
+
+### Backlog handling
+
+By default, when the connector starts it processes every message Telegram has
+queued since the last `getUpdates` call. If you'd rather only see new
+messages, set `TELEGRAM_DROP_PENDING=1` (or call `deleteWebhook` with
+`drop_pending_updates=true` which the connector does on startup if this flag
+is set). With the flag, the connector consumes one batch with `timeout=0` and
+advances its offset to skip past the queue.
+
+### Rate limiting
+
+A 5-second per-user rate limit is enforced using the standard
+`chat-bridge.json:rateLimitSeconds` setting. Configure via env
+`RATE_LIMIT_SECONDS` or the existing global config.
+
+### Privacy in groups
+
+By default a Telegram bot only receives messages that either (a) start with
+`/`, (b) mention the bot's @-username, or (c) are replies to the bot's own
+messages. If you want the bot to react to every message in a group (e.g., for
+the per-topic follow-up behavior), disable privacy via BotFather:
+
+```
+/setprivacy -> Disable
+```
+
+For private chats there is no such restriction.
+
+## Running as a Service
+
+### With nohup
+
+```bash
+nohup bun connectors/telegram.ts > logs/telegram.log 2>&1 &
+```
+
+### With systemd
+
+Create `/etc/systemd/system/opencode-telegram.service`:
+
+```ini
+[Unit]
+Description=OpenCode Telegram Bridge
+After=network.target
+
+[Service]
+Type=simple
+User=opencode
+WorkingDirectory=/opt/opencode-chat-bridge
+EnvironmentFile=/opt/opencode-chat-bridge/.env
+Environment=OPENCODE_CONFIG=/opt/opencode-chat-bridge/opencode.json
+ExecStart=/usr/local/bin/bun connectors/telegram.ts
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now opencode-telegram
+```
+
+### With Docker
+
+```bash
+docker compose up telegram
+```
+
+(`docker-compose.yml` ships with a pre-configured `telegram` service.)
+
+## Troubleshooting
+
+### "Error: TELEGRAM_BOT_TOKEN not set"
+
+The connector can't find a token. Make sure `.env` exists in the directory
+where you're running the connector, and that `TELEGRAM_BOT_TOKEN=...` is
+uncommented. The token from BotFather looks like
+`110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw` -- it should contain a colon.
+
+### Bot never responds in a group
+
+Two possible causes:
+
+1. **Privacy mode is on.** In Telegram, message
+   [@BotFather](https://t.me/BotFather) `/setprivacy` -> **Disable**.
+2. **The chat is in the `ignoreChats` list, or the user is in the
+   `ignoreUsers` / non-allowed list.** Check `chat-bridge.json` (or the
+   `TELEGRAM_ALLOWED_USERS` env var) and the logs for `[IGNORED]`.
+
+### Bot replies but says "I couldn't connect to the AI service"
+
+The connector authenticated with Telegram successfully but can't reach
+OpenCode. Make sure `OPENCODE_CONFIG` is set (if you customized the config
+file), that `opencode` is on the path, and that OpenCode is authenticated
+(`opencode auth status`).
+
+### 429 Too Many Requests
+
+The connector honors Telegram's `retry_after` parameter for 429 responses and
+backs off accordingly. If you see repeated 429s, you're either polling too
+aggressively (don't set `POLL_TIMEOUT_SECS` lower than 30) or running multiple
+connectors against the same bot token (each `getUpdates` call consumes your
+global rate limit).
+
+### Session messages from stale topics
+
+When `threadIsolation` is on, each forum topic gets its own session directory
+under `~/.cache/opencode-chat-bridge/sessions/telegram/<chatId>:<threadId>/`.
+On startup, sessions older than `SESSION_RETENTION_DAYS` (default 7) are
+removed. To also expire inactive sessions at runtime, set
+`SESSION_RETENTION_MINS=30`.
+
+To inspect a session's directory while debugging:
+
+```bash
+ls ~/.cache/opencode-chat-bridge/sessions/telegram/
+```
+
+## Security Notes
+
+- **Keep your bot token secret.** Anyone with the token can impersonate the
+  bot. Don't commit `.env` -- it's already in `.gitignore`.
+- **Use `TELEGRAM_ALLOWED_USERS` in production** unless you intend the bot to
+  be world-usable. Without it, anyone who messages the bot can drive the
+  connected OpenCode session.
+- **Bot privacy settings in groups** are independent of the `ignoreUsers`
+  list. Both apply.
+- Review the [Security documentation](SECURITY.md) for the OpenCode
+  permission model -- the connector enforces OpenCode's per-tool allowlist,
+  not prompt-based restrictions.
+
+## Architecture
+
+```
+Telegram Client App
+    ↓ (HTTPS long-poll)
+Telegram Bot API
+    ↓
+Telegram Connector (connectors/telegram.ts)
+    ↓ (ACP Protocol)
+OpenCode
+    ↓
+AI Response
+    ↓
+Telegram (via Bot API)
+```
+
+The connector maintains one ACP session per chat (or per topic with
+`threadIsolation`), allowing conversation continuity.
+
+## Limitations
+
+- **No group admin actions.** The connector does not handle Telegram admin
+  events like new members, left members, or pinned messages.
+- **Stickers / voice / video messages** are accepted but only their `caption`
+  is forwarded to OpenCode.
+- **Inline queries** are not handled. Trigger the bot by sending it a
+  message directly.
+- **Replies to non-text messages** (e.g., a sticker) without a caption are
+  ignored.
+- **One bot per connector instance.** Run multiple Telegram bots by
+  starting additional connector processes with separate
+  `TELEGRAM_BOT_TOKEN` env vars.

--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -149,12 +149,15 @@ is an independent sub-chat identified by `message_thread_id`.
 
 - `threadIsolation: true` (default): sessions are keyed on
   `${chatId}:${messageThreadId}`. Each topic has its own conversation history.
-  Replies are posted inside the topic using Telegram's `message_thread_id`
-  parameter, so the bot's response stays grouped with the conversation.
 - `threadIsolation: false`: one session per `chatId`. All topics in the
-  supergroup share conversation history. Replies in groups use
-  `reply_to_message_id` for visual continuity; topics are still respected if
-  the original message was in one.
+  supergroup share conversation history.
+
+In both cases, **replies are always posted inside the topic the user wrote
+from** (using `message_thread_id`). `threadIsolation` only controls SESSION
+keying -- reply routing is independent, because Telegram users expect the
+bot's response where they asked. Without this, replies in a topic would land
+in the supergroup's general chat root and be invisible to anyone navigating
+the forum.
 
 ### File uploads
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,9 +25,12 @@ case "$CONNECTOR" in
   mattermost)
     exec bun connectors/mattermost.ts
     ;;
+  telegram)
+    exec bun connectors/telegram.ts
+    ;;
   *)
     echo "Unknown connector: $CONNECTOR"
-    echo "Valid options: discord, slack, matrix, whatsapp, mattermost"
+    echo "Valid options: discord, slack, matrix, whatsapp, mattermost, telegram"
     exit 1
     ;;
 esac

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-chat-bridge",
   "version": "0.4.0",
-  "description": "Bridge OpenCode AI to chat platforms (Matrix, Slack, WhatsApp) with secure permission-based tool access",
+  "description": "Bridge OpenCode AI to chat platforms (Matrix, Slack, WhatsApp, Mattermost, Discord, Telegram, Web) with secure permission-based tool access",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,6 +20,7 @@
     "slack": "bun connectors/slack.ts",
     "whatsapp": "bun connectors/whatsapp.ts",
     "mattermost": "bun connectors/mattermost.ts",
+    "telegram": "bun connectors/telegram.ts",
     "cli": "bun src/cli.ts",
     "web": "bun connectors/web.ts"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,22 @@ export interface DiscordConfig {
   allowedUsers: string[]
 }
 
+export interface TelegramConfig {
+  enabled: boolean
+  /** Bot token from @BotFather -- env: TELEGRAM_BOT_TOKEN */
+  token: string
+  /** Respond when @-mentioned in groups (in addition to trigger) */
+  respondToMentions: boolean
+  /** Per-topic sessions in forum supergroups (chatId:messageThreadId).
+   *  When false, all messages in a chat share one session. */
+  threadIsolation: boolean
+  /** Comma-separated Telegram numeric chat IDs and/or user IDs to ignore */
+  ignoreChats: string[]
+  /** Comma-separated Telegram numeric user IDs to ignore */
+  ignoreUsers: string[]
+  allowedUsers: string[]
+}
+
 
 export interface WebConfig {
   enabled: boolean
@@ -77,6 +93,7 @@ export interface ChatBridgeConfig {
   whatsapp: WhatsAppConfig
   slack: SlackConfig
   discord: DiscordConfig
+  telegram: TelegramConfig
   web: WebConfig
 }
 
@@ -131,6 +148,15 @@ const defaultConfig: ChatBridgeConfig = {
   },
   discord: {
     enabled: false,
+    allowedUsers: [],
+  },
+  telegram: {
+    enabled: false,
+    token: "",
+    respondToMentions: true,
+    threadIsolation: true,
+    ignoreChats: [],
+    ignoreUsers: [],
     allowedUsers: [],
   },
   web: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { ACPClient, type ACPClientOptions, type MCPServer, type SessionUpdate, type ActivityEvent, type ImageContent, type OpenCodeCommand } from "./acp-client"
-export { getConfig, loadConfig, clearConfigCache, type ChatBridgeConfig, type MatrixConfig, type MattermostConfig, type WhatsAppConfig, type SlackConfig, type DiscordConfig } from "./config"
+export { getConfig, loadConfig, clearConfigCache, type ChatBridgeConfig, type MatrixConfig, type MattermostConfig, type WhatsAppConfig, type SlackConfig, type DiscordConfig, type TelegramConfig } from "./config"
 export { 
   getSessionDir, 
   ensureSessionDir, 

--- a/tests/integration/telegram-event-mapping.test.ts
+++ b/tests/integration/telegram-event-mapping.test.ts
@@ -228,8 +228,10 @@ describe("telegram event mapping integration", () => {
     )
     expect(a.sessionId).toBe(b.sessionId)
     expect(a.sessionId).toBe("-1001")
-    // messageThreadId is preserved on the context -- the connector decides
-    // whether to use it based on threadIsolation.
+    // messageThreadId is always preserved on the context. The connector
+    // uses it to pin replies to the originating topic regardless of
+    // threadIsolation; threadIsolation only controls how the session key
+    // is derived (chatId vs chatId:messageThreadId).
     expect(a.messageThreadId).toBe(5)
     expect(b.messageThreadId).toBe(6)
   })

--- a/tests/integration/telegram-event-mapping.test.ts
+++ b/tests/integration/telegram-event-mapping.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Integration tests for Telegram event-to-context mapping.
+ *
+ * Exercises full Telegram update payloads (raw shapes from getUpdates) and
+ * exercises the pure helpers together so the cross-connector invariants
+ * (sessionId, dedupeId, replyToMessageId, messageThreadId) stay coherent.
+ */
+
+import { describe, test, expect } from "bun:test"
+import {
+  normalizeTelegramEventContext,
+  buildTelegramSessionId,
+  resolveMessageThreadId,
+  type TelegramEventContext,
+} from "../../connectors/telegram"
+
+/** Build a raw Telegram update-shape payload -- mirrors what getUpdates delivers. */
+function tgUpdate(opts: {
+  chatId: number | string
+  chatType?: string
+  isForum?: boolean
+  from: number | string
+  username?: string
+  firstName?: string
+  messageId: number
+  text?: string
+  caption?: string
+  isTopicMessage?: boolean
+  messageThreadId?: number
+  replyToMessageId?: number
+  isBot?: boolean
+  updateId?: number
+}): Record<string, unknown> {
+  const chat: Record<string, unknown> = {
+    id: opts.chatId,
+    type: opts.chatType ?? "supergroup",
+  }
+  if (opts.isForum) chat.is_forum = true
+
+  const from: Record<string, unknown> = {
+    id: opts.from,
+    is_bot: !!opts.isBot,
+  }
+  if (opts.username) from.username = opts.username
+  if (opts.firstName) from.first_name = opts.firstName
+
+  const message: Record<string, unknown> = {
+    message_id: opts.messageId,
+    from,
+    chat,
+    date: 1_700_000_000,
+  }
+  if (opts.text !== undefined) message.text = opts.text
+  if (opts.caption !== undefined) message.caption = opts.caption
+  if (opts.isTopicMessage) message.is_topic_message = true
+  if (opts.messageThreadId !== undefined) message.message_thread_id = opts.messageThreadId
+  if (opts.replyToMessageId !== undefined) {
+    message.reply_to_message = { message_id: opts.replyToMessageId }
+  }
+
+  return {
+    update_id: opts.updateId ?? opts.messageId,
+    message,
+  }
+}
+
+/** Run a raw update payload through our normalizer (mirrors handleUpdate's call). */
+function map(raw: Record<string, unknown>, threadIsolation = true): TelegramEventContext {
+  const message = raw.message as Record<string, unknown>
+  const chat = message.chat as { id: number | string; type: string; is_forum?: boolean }
+  const from = message.from as { id: number | string; is_bot?: boolean; username?: string; first_name?: string }
+
+  return normalizeTelegramEventContext(
+    {
+      chat,
+      from,
+      messageId: Number(message.message_id),
+      text: String(message.text || message.caption || ""),
+      is_topic_message: message.is_topic_message as boolean | undefined,
+      message_thread_id: message.message_thread_id as number | undefined,
+      reply_to_message: message.reply_to_message as { message_id: number } | undefined,
+    },
+    threadIsolation
+  )
+}
+
+describe("telegram event mapping integration", () => {
+  test("forum-topic trigger maps to chatId:threadId session", () => {
+    const ctx = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: true,
+        from: 42,
+        messageId: 100,
+        text: "!oc summarize this topic",
+        isTopicMessage: true,
+        messageThreadId: 7,
+      })
+    )
+    expect(ctx.sessionId).toBe("-1001:7")
+    expect(ctx.isForumTopic).toBe(true)
+    expect(ctx.messageThreadId).toBe(7)
+    expect(ctx.dedupeId).toBe("-1001:100")
+    expect(ctx.replyToMessageId).toBeNull()
+  })
+
+  test("two forum topics in the same chat get isolated sessions", () => {
+    const a = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: true,
+        from: 42,
+        messageId: 1,
+        text: "x",
+        isTopicMessage: true,
+        messageThreadId: 5,
+      })
+    )
+    const b = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: true,
+        from: 42,
+        messageId: 2,
+        text: "y",
+        isTopicMessage: true,
+        messageThreadId: 6,
+      })
+    )
+    expect(a.sessionId).toBe("-1001:5")
+    expect(b.sessionId).toBe("-1001:6")
+    expect(a.sessionId).not.toBe(b.sessionId)
+  })
+
+  test("plain message in non-forum supergroup maps to chatId", () => {
+    const ctx = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: false,
+        from: 1,
+        messageId: 10,
+        text: "!oc hi",
+      })
+    )
+    expect(ctx.messageThreadId).toBeNull()
+    expect(ctx.sessionId).toBe("-1001")
+    expect(ctx.isForumTopic).toBe(false)
+  })
+
+  test("DM: every message routes to the same per-user chatId", () => {
+    const a = map(
+      tgUpdate({
+        chatId: 99,
+        chatType: "private",
+        from: 42,
+        messageId: 1,
+        text: "!oc hi",
+      })
+    )
+    const b = map(
+      tgUpdate({
+        chatId: 99,
+        chatType: "private",
+        from: 42,
+        messageId: 2,
+        text: "!oc follow up",
+      })
+    )
+    expect(a.sessionId).toBe("99")
+    expect(b.sessionId).toBe("99")
+    expect(a.dedupeId).toBe("99:1")
+    expect(b.dedupeId).toBe("99:2")
+  })
+
+  test("caption is used when text is absent", () => {
+    const ctx = map(
+      tgUpdate({
+        chatId: 99,
+        chatType: "private",
+        from: 42,
+        messageId: 5,
+        caption: "!oc what's in this photo?",
+      })
+    )
+    expect(ctx.text).toBe("!oc what's in this photo?")
+  })
+
+  test("reply_to_message_id is preserved for visual replies", () => {
+    const ctx = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: false,
+        from: 42,
+        messageId: 200,
+        text: "!oc explain",
+        replyToMessageId: 199,
+      })
+    )
+    expect(ctx.replyToMessageId).toBe(199)
+    expect(ctx.sessionId).toBe("-1001")
+    expect(ctx.messageThreadId).toBeNull()
+  })
+
+  test("threadIsolation off collapses all topics in a chat to one session", () => {
+    const a = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: true,
+        from: 42,
+        messageId: 1,
+        text: "x",
+        isTopicMessage: true,
+        messageThreadId: 5,
+      }),
+      false
+    )
+    const b = map(
+      tgUpdate({
+        chatId: -1001,
+        isForum: true,
+        from: 42,
+        messageId: 2,
+        text: "y",
+        isTopicMessage: true,
+        messageThreadId: 6,
+      }),
+      false
+    )
+    expect(a.sessionId).toBe(b.sessionId)
+    expect(a.sessionId).toBe("-1001")
+    // messageThreadId is preserved on the context -- the connector decides
+    // whether to use it based on threadIsolation.
+    expect(a.messageThreadId).toBe(5)
+    expect(b.messageThreadId).toBe(6)
+  })
+
+  test("dedupe IDs are unique across chats and messages", () => {
+    const a = map(
+      tgUpdate({ chatId: 1, chatType: "private", from: 1, messageId: 1, text: "hi" })
+    )
+    const b = map(
+      tgUpdate({ chatId: 2, chatType: "private", from: 1, messageId: 1, text: "hi" })
+    )
+    expect(a.dedupeId).toBe("1:1")
+    expect(b.dedupeId).toBe("2:1")
+    expect(a.dedupeId).not.toBe(b.dedupeId)
+  })
+
+  test("build / resolve / normalize are mutually consistent", () => {
+    // Round-trip: take a raw payload, normalize, then re-derive sessionId
+    // the same way buildTelegramSessionId does internally.
+    const raw = tgUpdate({
+      chatId: -1009,
+      isForum: true,
+      from: 7,
+      messageId: 11,
+      text: "!oc go",
+      isTopicMessage: true,
+      messageThreadId: 99,
+    })
+    const ctx = map(raw, true)
+    const expectedSession = buildTelegramSessionId(
+      ctx.chatId,
+      resolveMessageThreadId({
+        is_topic_message: raw.message?.is_topic_message as boolean | undefined,
+        message_thread_id: raw.message?.message_thread_id as number | undefined,
+      }),
+      true
+    )
+    expect(ctx.sessionId).toBe(expectedSession)
+    expect(ctx.sessionId).toBe("-1009:99")
+  })
+})

--- a/tests/unit/telegram-thread-context.test.ts
+++ b/tests/unit/telegram-thread-context.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for Telegram thread context helpers
+ * Tests the pure functions exported from connectors/telegram.ts
+ */
+
+import { describe, test, expect } from "bun:test"
+import {
+  resolveMessageThreadId,
+  buildTelegramSessionId,
+  normalizeTelegramEventContext,
+  shouldHandleImplicitTopicReply,
+  type TelegramNormalizeInput,
+} from "../../connectors/telegram"
+
+// =============================================================================
+// resolveMessageThreadId
+// =============================================================================
+
+describe("resolveMessageThreadId", () => {
+  test("returns threadId when is_topic_message and message_thread_id present", () => {
+    expect(
+      resolveMessageThreadId({ is_topic_message: true, message_thread_id: 17 })
+    ).toBe(17)
+  })
+
+  test("returns null when not a topic message", () => {
+    expect(
+      resolveMessageThreadId({ is_topic_message: false, message_thread_id: 17 })
+    ).toBeNull()
+  })
+
+  test("returns null when is_topic_message missing", () => {
+    expect(resolveMessageThreadId({ message_thread_id: 17 })).toBeNull()
+  })
+
+  test("returns null when message_thread_id is not a number", () => {
+    expect(
+      resolveMessageThreadId({ is_topic_message: true, message_thread_id: undefined })
+    ).toBeNull()
+  })
+
+  test("returns null on empty input", () => {
+    expect(resolveMessageThreadId({})).toBeNull()
+  })
+})
+
+// =============================================================================
+// buildTelegramSessionId
+// =============================================================================
+
+describe("buildTelegramSessionId", () => {
+  test("uses chatId:threadId when threadIsolation is on and threadId set", () => {
+    expect(buildTelegramSessionId("100", 7, true)).toBe("100:7")
+  })
+
+  test("uses chatId only when threadIsolation is on but no threadId", () => {
+    expect(buildTelegramSessionId("100", null, true)).toBe("100")
+  })
+
+  test("uses chatId only when threadIsolation is off", () => {
+    expect(buildTelegramSessionId("100", 7, false)).toBe("100")
+  })
+
+  test("uses chatId only when threadIsolation is off and no threadId", () => {
+    expect(buildTelegramSessionId("-1001234567890", null, false)).toBe("-1001234567890")
+  })
+
+  test("two topics in same chat get different IDs when isolation is on", () => {
+    const a = buildTelegramSessionId("-100", 5, true)
+    const b = buildTelegramSessionId("-100", 6, true)
+    expect(a).not.toBe(b)
+  })
+
+  test("two topics in same chat share an ID when isolation is off", () => {
+    const a = buildTelegramSessionId("-100", 5, false)
+    const b = buildTelegramSessionId("-100", 6, false)
+    expect(a).toBe(b)
+  })
+})
+
+// =============================================================================
+// normalizeTelegramEventContext
+// =============================================================================
+
+const baseInput: TelegramNormalizeInput = {
+  chat: { id: 100, type: "supergroup", is_forum: true },
+  from: { id: 42, username: "alice", first_name: "Alice" },
+  messageId: 9001,
+  text: "  hello there  ",
+  is_topic_message: true,
+  message_thread_id: 7,
+}
+
+describe("normalizeTelegramEventContext", () => {
+  test("normalizes a forum-topic message with threadIsolation on", () => {
+    const ctx = normalizeTelegramEventContext(baseInput, true)
+
+    expect(ctx.chatId).toBe("100")
+    expect(ctx.userId).toBe("42")
+    expect(ctx.messageId).toBe(9001)
+    expect(ctx.text).toBe("hello there")
+    expect(ctx.messageThreadId).toBe(7)
+    expect(ctx.chatType).toBe("supergroup")
+    expect(ctx.isForumTopic).toBe(true)
+    expect(ctx.isPrivate).toBe(false)
+    expect(ctx.sessionId).toBe("100:7")
+    expect(ctx.dedupeId).toBe("100:9001")
+    expect(ctx.replyToMessageId).toBeNull()
+  })
+
+  test("normalizes a private chat with threadIsolation off", () => {
+    const ctx = normalizeTelegramEventContext(
+      {
+        chat: { id: 99, type: "private" },
+        from: { id: 42 },
+        messageId: 1,
+        text: "hi",
+      },
+      false
+    )
+    expect(ctx.chatId).toBe("99")
+    expect(ctx.userId).toBe("42")
+    expect(ctx.isPrivate).toBe(true)
+    expect(ctx.isForumTopic).toBe(false)
+    expect(ctx.messageThreadId).toBeNull()
+    expect(ctx.sessionId).toBe("99")
+    expect(ctx.dedupeId).toBe("99:1")
+  })
+
+  test("non-topic supergroup message with threadIsolation on uses chatId as session", () => {
+    const ctx = normalizeTelegramEventContext(
+      {
+        chat: { id: -1000, type: "supergroup" },
+        from: { id: 1 },
+        messageId: 2,
+        text: "hi",
+      },
+      true
+    )
+    expect(ctx.messageThreadId).toBeNull()
+    expect(ctx.isForumTopic).toBe(false)
+    expect(ctx.sessionId).toBe("-1000")
+  })
+
+  test("forum supergroup but non-topic message uses chatId as session", () => {
+    const ctx = normalizeTelegramEventContext(
+      {
+        chat: { id: -1000, type: "supergroup", is_forum: true },
+        from: { id: 1 },
+        messageId: 3,
+        text: "general topic",
+        // is_topic_message undefined
+      },
+      true
+    )
+    expect(ctx.isForumTopic).toBe(false)
+    expect(ctx.messageThreadId).toBeNull()
+    expect(ctx.sessionId).toBe("-1000")
+  })
+
+  test("threadIsolation off routes forum topic messages to chatId", () => {
+    const ctx = normalizeTelegramEventContext(baseInput, false)
+    expect(ctx.messageThreadId).toBe(7) // preserved
+    expect(ctx.sessionId).toBe("100") // collapsed
+  })
+
+  test("reply_to_message_id is preserved", () => {
+    const ctx = normalizeTelegramEventContext(
+      { ...baseInput, reply_to_message: { message_id: 1234 } },
+      true
+    )
+    expect(ctx.replyToMessageId).toBe(1234)
+  })
+
+  test("handles missing optional fields", () => {
+    const ctx = normalizeTelegramEventContext(
+      {
+        chat: { id: 1, type: "private" },
+        from: { id: 2 },
+        messageId: 3,
+      },
+      true
+    )
+    expect(ctx.text).toBe("")
+    expect(ctx.messageThreadId).toBeNull()
+    expect(ctx.replyToMessageId).toBeNull()
+    expect(ctx.isForumTopic).toBe(false)
+    expect(ctx.sessionId).toBe("1")
+  })
+
+  test("stringifies numeric IDs so the session key is filesystem-safe", () => {
+    const ctx = normalizeTelegramEventContext(
+      {
+        chat: { id: -1001234567890, type: "supergroup" },
+        from: { id: 987654321 },
+        messageId: 10,
+      },
+      false
+    )
+    expect(ctx.chatId).toBe("-1001234567890")
+    expect(ctx.userId).toBe("987654321")
+  })
+})
+
+// =============================================================================
+// shouldHandleImplicitTopicReply
+// =============================================================================
+
+describe("shouldHandleImplicitTopicReply", () => {
+  test("accepts plain topic replies", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "continue this",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+        botUsername: "ocbot",
+      })
+    ).toBe(true)
+  })
+
+  test("rejects DM (private chat)", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "continue",
+        isPrivate: true,
+        messageThreadId: 7,
+        trigger: "!oc",
+      })
+    ).toBe(false)
+  })
+
+  test("rejects when messageThreadId is null (not in a topic)", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "continue",
+        isPrivate: false,
+        messageThreadId: null,
+        trigger: "!oc",
+      })
+    ).toBe(false)
+  })
+
+  test("rejects trigger-prefixed messages", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "!oc do something",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+        botUsername: "ocbot",
+      })
+    ).toBe(false)
+  })
+
+  test("rejects bare trigger", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "!oc",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+      })
+    ).toBe(false)
+  })
+
+  test("rejects @mention messages", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "@ocbot hi",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+        botUsername: "ocbot",
+      })
+    ).toBe(false)
+  })
+
+  test("rejects empty text", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+      })
+    ).toBe(false)
+  })
+
+  test("trigger matching is case-insensitive", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "!OC do something",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+      })
+    ).toBe(false)
+  })
+
+  test("@mention matching is case-insensitive", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "@OCBot hi",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+        botUsername: "ocbot",
+      })
+    ).toBe(false)
+  })
+
+  test("works without botUsername", () => {
+    expect(
+      shouldHandleImplicitTopicReply({
+        text: "plain reply",
+        isPrivate: false,
+        messageThreadId: 7,
+        trigger: "!oc",
+      })
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a new **Telegram** connector that bridges chats to OpenCode via the
Bot API over HTTPS. Zero external runtime dependencies -- uses native
`fetch` and long-polling `getUpdates`, so no webhook or public port is
required.

Mirrors the existing Mattermost connector's shape, including the same
thread-isolation model (per-topic sessions in forum supergroups).

## What's included

- `connectors/telegram.ts` -- the connector (~920 LOC, zero deps)
  - Trigger prefix (`!oc`), `@`-mentions, auto-handled DMs
  - Per-topic session isolation in forum supergroups
    (`chatId:messageThreadId`); plain replies in an active topic continue
    the conversation without re-mentioning
  - `sendPhoto` / `sendDocument` attachments for tool outputs
  - Long-message splitting at the 4096-char Telegram limit
  - `sendChatAction` typing indicator
  - Exponential backoff with `retry_after` honored for 429s
  - `TELEGRAM_ALLOWED_USERS` allowlist, `ignoreChats` / `ignoreUsers`
    blocklists, `TELEGRAM_DROP_PENDING=1` opt-in
- Pure helpers exported for testing (`resolveMessageThreadId`,
  `buildTelegramSessionId`, `normalizeTelegramEventContext`,
  `shouldHandleImplicitTopicReply`)
- `TelegramConfig` in `src/config.ts` with full defaults
- 27 unit tests (`tests/unit/telegram-thread-context.test.ts`) and
  9 integration tests (`tests/integration/telegram-event-mapping.test.ts`),
  modelled on the existing Mattermost test files
- `docs/TELEGRAM_SETUP.md` walkthrough (BotFather, env, behavior
  reference, troubleshooting, systemd unit)
- Wiring through `package.json` (`bun run telegram`), `entrypoint.sh`,
  `docker-compose.yml`, `Dockerfile`, `.env.example`,
  `config.example.json`, plus `README.md` / `CHANGELOG.md` /
  `docs/CONTRIBUTING.md` updates

## Status: WIP

The connector was implemented and reviewed locally, but **`bun` is not
available in the environment that produced this PR**, so `bun run
typecheck` and `bun test` could not be run before opening the PR.
CI on this PR should surface any fixes needed.

Specifically worth validating on CI:

- `bun run typecheck` -- types may need small adjustments around the
  `Record<string, unknown>` index access for raw Telegram updates
- `bun test` -- unit and integration test pass
- `bun run check:connectors` -- `bun build` succeeds for
  `connectors/telegram.ts`

If CI flags issues I'll fix them in follow-up commits before marking
this PR ready for review.

## Setup (for maintainer testing)

1. Create a bot via [@BotFather](https://t.me/BotFather) and copy the
   token.
2. Add to `.env`:
   ```env
   TELEGRAM_BOT_TOKEN=<token>
   ```
3. Either run with `bun run telegram` or `docker compose up telegram`.
4. DM the bot with `!oc hello` to verify.

See `docs/TELEGRAM_SETUP.md` for the full setup, behavior reference,
and troubleshooting section.

## Checklist

- [ ] CI passes (`bun run typecheck`, `bun test`, `bun run check:connectors`)
- [ ] Manual smoke test against a live bot (author can provide if needed)
- [ ] Screenshots / demo GIF (optional)