### PR TITLE
fix: support JSONC bridge configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 config.json
 !config.example.json
 chat-bridge.json
+chat-bridge.jsonc
 !chat-bridge.json.example
 
 # OpenCode local config (may contain secrets from MCP environment blocks)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,8 +5,11 @@ This document describes all configuration options for opencode-chat-bridge.
 ## Quick Setup
 
 1. Copy `chat-bridge.json.example` to `chat-bridge.json` and edit local bridge settings
-2. Create `opencode.json` with the `chat-bridge` agent
-3. Run `bun src/cli.ts`
+2. Alternatively, use `chat-bridge.jsonc` when comments or trailing commas are useful
+3. Create `opencode.json` with the `chat-bridge` agent
+4. Run `bun src/cli.ts`
+
+The loader checks `chat-bridge.json` first, then `chat-bridge.jsonc`. JSONC files support `//` and `/* ... */` comments, trailing commas, and `{env:VAR_NAME}` environment variable substitution.
 
 `chat-bridge.json` is intentionally ignored by git. Keep deployment-specific connector settings, local paths, and credentials there. Commit safe defaults or examples to `chat-bridge.json.example` instead.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 /**
  * Configuration loader for chat-bridge
  * 
- * Loads settings from chat-bridge.json with environment variable substitution.
+ * Loads settings from chat-bridge.json or chat-bridge.jsonc with environment
+ * variable substitution.
  */
 
 import * as fs from "fs"
@@ -198,6 +199,129 @@ const defaultConfig: ChatBridgeConfig = {
 }
 
 /**
+ * Remove JSONC comments while preserving strings and line structure so that
+ * JSON.parse can still report useful line/column information for malformed
+ * configuration files.
+ */
+function stripJsoncComments(content: string): string {
+  let result = ""
+  let inString = false
+  let escaped = false
+  let lineComment = false
+  let blockComment = false
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i]
+    const next = content[i + 1]
+
+    if (lineComment) {
+      if (char === "\n" || char === "\r") {
+        lineComment = false
+        result += char
+      } else {
+        result += " "
+      }
+      continue
+    }
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false
+        result += "  "
+        i++
+      } else if (char === "\n" || char === "\r") {
+        result += char
+      } else {
+        result += " "
+      }
+      continue
+    }
+
+    if (inString) {
+      result += char
+      if (escaped) {
+        escaped = false
+      } else if (char === "\\") {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      result += char
+    } else if (char === "/" && next === "/") {
+      lineComment = true
+      result += "  "
+      i++
+    } else if (char === "/" && next === "*") {
+      blockComment = true
+      result += "  "
+      i++
+    } else {
+      result += char
+    }
+  }
+
+  return result
+}
+
+/**
+ * JSONC commonly permits trailing commas as well as comments. Remove commas
+ * immediately before a closing array/object delimiter without touching
+ * commas inside strings.
+ */
+function stripJsoncTrailingCommas(content: string): string {
+  let result = ""
+  let inString = false
+  let escaped = false
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i]
+
+    if (inString) {
+      result += char
+      if (escaped) {
+        escaped = false
+      } else if (char === "\\") {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      result += char
+      continue
+    }
+
+    if (char === ",") {
+      let next = i + 1
+      while (next < content.length && /\s/.test(content[next])) {
+        next++
+      }
+      if (content[next] === "}" || content[next] === "]") {
+        continue
+      }
+    }
+
+    result += char
+  }
+
+  return result
+}
+
+function parseJsonc(content: string): unknown {
+  const withoutBom = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content
+  const withoutComments = stripJsoncComments(withoutBom)
+  return JSON.parse(stripJsoncTrailingCommas(withoutComments))
+}
+
+/**
  * Replace {env:VAR_NAME} patterns with environment variables
  */
 function substituteEnvVars(obj: any): any {
@@ -241,7 +365,7 @@ function deepMerge<T>(target: T, source: Partial<T>): T {
 let cachedConfig: ChatBridgeConfig | null = null
 
 /**
- * Load configuration from chat-bridge.json
+ * Load configuration from chat-bridge.json or chat-bridge.jsonc
  */
 export function loadConfig(configPath?: string): ChatBridgeConfig {
   if (cachedConfig) return cachedConfig
@@ -257,7 +381,7 @@ export function loadConfig(configPath?: string): ChatBridgeConfig {
     if (fs.existsSync(filePath)) {
       try {
         const content = fs.readFileSync(filePath, "utf-8")
-        const parsed = JSON.parse(content)
+        const parsed = parseJsonc(content)
         const substituted = substituteEnvVars(parsed)
         cachedConfig = deepMerge(defaultConfig, substituted)
         console.log(`[CONFIG] Loaded from ${filePath}`)

--- a/tests/integration/config.test.ts
+++ b/tests/integration/config.test.ts
@@ -66,6 +66,26 @@ describe("config", () => {
       expect(config.rateLimitSeconds).toBe(10)
     })
 
+    test("loads config from chat-bridge.jsonc with comments and trailing commas", () => {
+      const configContent = `{
+        // The JSONC loader should ignore line comments.
+        "botName": "jsonc-bot",
+        "telegram": {
+          /* Block comments are supported too. */
+          "threadIsolation": false,
+          "token": "https://example.test/path/*not a comment*/",
+        },
+      }`
+      fs.writeFileSync(path.join(testDir, "chat-bridge.jsonc"), configContent)
+      process.chdir(testDir)
+
+      const config = loadConfig()
+
+      expect(config.botName).toBe("jsonc-bot")
+      expect(config.telegram.threadIsolation).toBe(false)
+      expect(config.telegram.token).toBe("https://example.test/path/*not a comment*/")
+    })
+
     test("merges with defaults for partial config", () => {
       const configContent = {
         botName: "partial-bot"


### PR DESCRIPTION
I found it useful to include comments in the bridge config json, and docs said it was supported (but it wasn't). This description is carbon-edited (could you guess?)