### PR TITLE
Format trade-offs table with uniform column widths

### DIFF
--- a/docs/MATRIX_ARCHITECTURE.md
+++ b/docs/MATRIX_ARCHITECTURE.md
@@ -21,15 +21,15 @@ Issue [#1](https://github.com/ominiverdi/opencode-chat-bridge/issues/1) raised t
 
 ### Trade-offs
 
-| Aspect | Simple Login | Application Service |
-|--------|--------------|---------------------|
-| Setup complexity | Username/password | Registration YAML + homeserver config |
-| Server requirements | Any Matrix account | Homeserver admin access required |
-| Accessibility | Works on matrix.org, any public server | Self-hosted servers only |
-| Virtual users | No | Yes |
-| Rate limits | Standard | Exempt |
-| Event delivery | Polling (sync) | HTTP push (webhooks) |
-| Best for | Bots, assistants | Protocol bridges |
+| Aspect              | Simple Login                           | Application Service                   |
+| ------------------- | -------------------------------------- | ------------------------------------- |
+| Setup complexity    | Username/password                      | Registration YAML + homeserver config |
+| Server requirements | Any Matrix account                     | Homeserver admin access required      |
+| Accessibility       | Works on matrix.org, any public server | Self-hosted servers only              |
+| Virtual users       | No                                     | Yes                                   |
+| Rate limits         | Standard                               | Exempt                                |
+| Event delivery      | Polling (sync)                         | HTTP push (webhooks)                  |
+| Best for            | Bots, assistants                       | Protocol bridges                      |
 
 ### Decision
 


### PR DESCRIPTION
Align pipes and pad each column to a consistent width so the trade-offs table in `docs/MATRIX_ARCHITECTURE.md` renders cleanly in Markdown viewers.

```
$ git diff --stat main...markdown-tables
 docs/MATRIX_ARCHITECTURE.md | 18 +++++++++---------
 1 file changed, 9 insertions(+), 9 deletions(-)
```