### PR TITLE
Add trustedDependencies for matrix-sdk-crypto-nodejs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@matrix-org/matrix-sdk-crypto-nodejs",
+  ],
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.13.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, ""],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "matrix-bot-sdk": "^0.8.0",
     "qrcode-terminal": "^0.12.0"
   },
+  "trustedDependencies": [
+    "@matrix-org/matrix-sdk-crypto-nodejs"
+  ],
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5.0.0"


### PR DESCRIPTION
Bun never runs lifecycle scripts from dependencies by default. The `@matrix-org/matrix-sdk-crypto-nodejs` package relies on a `postinstall` hook to download the platform-specific native Rust binary (.node file) from GitHub releases.

Without this, running `bun install` results in:

```
Cannot find module '@matrix-org/matrix-sdk-crypto-nodejs-linux-x64-gnu'
```

Adding the package to `trustedDependencies` lets bun execute its postinstall, which fetches the correct binary for the current platform.