### PR TITLE
Ignore redacted Matrix messages

### DIFF
--- a/connectors/matrix.ts
+++ b/connectors/matrix.ts
@@ -32,7 +32,6 @@ import {
   LogService,
   MatrixAuth,
   MatrixClient,
-  MessageEvent,
   RichConsoleLogger,
   RustSdkCryptoStorageProvider,
   SimpleFsStorageProvider,
@@ -171,7 +170,11 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
       this.log(`[CRYPTO] Failed to decrypt in ${roomId}: ${error.message}`)
     })
 
-    this.matrix.on("room.message", this.handleRoomMessage.bind(this))
+    this.matrix.on("room.message", (roomId: string, event: any) => {
+      this.handleRoomMessage(roomId, event).catch((err) => {
+        this.logError(`Failed to handle Matrix message in ${roomId}:`, err)
+      })
+    })
     await this.matrix.start()
 
     this.startSessionExpiryLoop()
@@ -355,16 +358,22 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
   // ---------------------------------------------------------------------------
 
   private async handleRoomMessage(roomId: string, event: any): Promise<void> {
-    const message = new MessageEvent(event)
+    // Redacted events have empty content, and malformed events may contain
+    // non-string fields. Reading those through MessageEvent's getters throws,
+    // so validate the raw event before doing any asynchronous work.
+    const content = event?.content
+    if (!content || typeof content !== "object") return
+    if (content.msgtype !== "m.text" || typeof content.body !== "string") return
 
-    if (message.messageType !== "m.text") return
+    const sender = event?.sender
+    if (typeof sender !== "string" || !sender) return
+
+    const body = content.body.trim()
+    if (!body) return
 
     const myUserId = await this.matrix!.getUserId()
-    if (message.sender === myUserId) return
-    if (!this.isUserAllowed(message.sender)) return
-
-    const body = message.textBody.trim()
-    if (!body) return
+    if (sender === myUserId) return
+    if (!this.isUserAllowed(sender)) return
 
     // Deduplicate events (Matrix sync replays)
     if (this.isDuplicateEvent(event.event_id || `${roomId}:${Date.now()}`)) return
@@ -373,7 +382,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
 
     const context = normalizeMatrixEventContext({
       roomId,
-      sender: message.sender,
+      sender,
       text: body,
       eventId: event.event_id,
       threadRootEventId,
@@ -407,7 +416,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
     }) && this.sessionManager.has(context.sessionId)) {
       // Implicit thread follow-up
       query = body
-      this.log(`[THREAD] ${message.sender} in ${context.sessionId}: ${body}`)
+      this.log(`[THREAD] ${sender} in ${context.sessionId}: ${body}`)
     } else {
       return
     }
@@ -415,7 +424,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
     query = query.replace(/^[:\s]+/, "").trim()
     if (!query) return
 
-    this.log(`[MSG] ${message.sender} in ${context.sessionId}: ${body}`)
+    this.log(`[MSG] ${sender} in ${context.sessionId}: ${body}`)
 
     await this.stopMirrorForUserActivity(context.sessionId, query, async (text) => {
       await this.sendNoticeReply(context, text)
@@ -434,12 +443,12 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
       }
 
       this.log(`[CMD] Forwarding to OpenCode: ${query}`)
-      if (!this.checkRateLimit(message.sender)) return
+      if (!this.checkRateLimit(sender)) return
       await this.processQuery(context, query)
       return
     }
 
-    if (!this.checkRateLimit(message.sender)) return
+    if (!this.checkRateLimit(sender)) return
     await this.processQuery(context, query)
   }
 

--- a/tests/unit/matrix-empty-response.test.ts
+++ b/tests/unit/matrix-empty-response.test.ts
@@ -86,6 +86,35 @@ async function processQuery(fake: ReturnType<typeof fakeConnector>): Promise<voi
   await (MatrixConnector.prototype as any).processQuery.call(fake.connector, context, "summarize")
 }
 
+describe("Matrix room message validation", () => {
+  test("ignores redacted events without msgtype", async () => {
+    const event = {
+      type: "m.room.message",
+      event_id: "$redacted",
+      sender: "@user:example.org",
+      content: {},
+      unsigned: { redacted_because: { type: "m.room.redaction" } },
+    }
+
+    await expect(
+      (MatrixConnector.prototype as any).handleRoomMessage.call({}, "!room:example.org", event),
+    ).resolves.toBeUndefined()
+  })
+
+  test("ignores malformed text events without a string body", async () => {
+    const event = {
+      type: "m.room.message",
+      event_id: "$malformed",
+      sender: "@user:example.org",
+      content: { msgtype: "m.text", body: 42 },
+    }
+
+    await expect(
+      (MatrixConnector.prototype as any).handleRoomMessage.call({}, "!room:example.org", event),
+    ).resolves.toBeUndefined()
+  })
+})
+
 describe("Matrix empty ACP responses", () => {
   test("retries once with a fresh session and sends the recovered response", async () => {
     const fake = fakeConnector("", "recovered answer")


### PR DESCRIPTION
## Summary

- validate raw Matrix message fields before processing
- ignore redacted and malformed message events instead of throwing
- catch asynchronous room-message handler failures
- add regression coverage for missing `msgtype` and invalid message bodies

## Verification

- `bun test tests/unit/matrix-empty-response.test.ts`
- `bun run typecheck`
- `bun build connectors/matrix.ts --outdir /tmp/opencode-chat-bridge-main-matrix-check --target node --format esm`