### PR TITLE
Snapshot opencode.json by content hash, not mtime

### DIFF
--- a/src/session-utils.ts
+++ b/src/session-utils.ts
@@ -73,24 +73,42 @@ export function ensureSessionDir(sessionDir: string): void {
 }
 
 /**
- * Copy a config file to session directory if source is newer or target doesn't exist.
+ * Copy a config file to session directory if source content differs from target.
+ * Returns true if the file was actually refreshed (added or replaced), false otherwise.
+ *
+ * Using a content hash instead of mtime avoids two pitfalls:
+ *   - `git checkout` / restores can produce a source file whose mtime is older
+ *     than the cached snapshot, even though the content actually changed.
+ *   - edits that preserve mtime would otherwise leave stale config in place.
  */
-function copyIfNewer(sourceDir: string, sessionDir: string, fileName: string): void {
+function copyIfChanged(sourceDir: string, sessionDir: string, fileName: string): boolean {
   const sourcePath = path.join(sourceDir, fileName)
   const targetPath = path.join(sessionDir, fileName)
-  
-  if (fs.existsSync(sourcePath)) {
+
+  if (!fs.existsSync(sourcePath)) return false
+
+  const sourceHash = hashFile(sourcePath)
+  const targetHash = fs.existsSync(targetPath) ? hashFile(targetPath) : null
+
+  if (sourceHash && sourceHash !== targetHash) {
     try {
-      const sourceStats = fs.statSync(sourcePath)
-      const targetExists = fs.existsSync(targetPath)
-      
-      if (!targetExists || sourceStats.mtime > fs.statSync(targetPath).mtime) {
-        fs.copyFileSync(sourcePath, targetPath)
-        console.log(`  Copied ${fileName} to session directory`)
-      }
+      fs.copyFileSync(sourcePath, targetPath)
+      console.log(`  Refreshed ${fileName} in session directory (content changed)`)
+      return true
     } catch (err) {
       console.error(`Failed to copy ${fileName}:`, err)
+      return false
     }
+  }
+  return false
+}
+
+function hashFile(filePath: string): string | null {
+  try {
+    const buf = fs.readFileSync(filePath)
+    return createHash("sha256").update(buf).digest("hex")
+  } catch {
+    return null
   }
 }
 
@@ -124,24 +142,52 @@ function symlinkDir(sourceDir: string, sessionDir: string, dirName: string): voi
 
 /**
  * Copy config files to session directory.
- * 
+ *
  * OpenCode looks for config in the working directory (cwd).
  * Since sessions run from ~/.cache/..., we copy these files there:
  * - opencode.json: Agent config with tool permissions
  * - AGENTS.md: Instructions that override global AGENTS.md
  * - .opencode/skills/: Symlinked for skill discovery
- * 
+ *
+ * Copies are content-based, not mtime-based, so restores and
+ * timestamp-preserving edits are still picked up.
+ *
  * @param sessionDir - Target session directory
  * @param projectDir - Source project directory (default: process.cwd())
+ * @returns true if any file was actually refreshed, false otherwise.
  */
-export function copyOpenCodeConfig(sessionDir: string, projectDir?: string): void {
+export function copyOpenCodeConfig(sessionDir: string, projectDir?: string): boolean {
   const sourceDir = projectDir || process.cwd()
-  
-  copyIfNewer(sourceDir, sessionDir, "opencode.json")
-  copyIfNewer(sourceDir, sessionDir, "AGENTS.md")
-  
+
+  let refreshed = false
+  refreshed = copyIfChanged(sourceDir, sessionDir, "opencode.json") || refreshed
+  refreshed = copyIfChanged(sourceDir, sessionDir, "AGENTS.md") || refreshed
+
   // Symlink .opencode directory for skills, tools, commands
   symlinkDir(sourceDir, sessionDir, ".opencode")
+
+  return refreshed
+}
+
+/**
+ * Returns true if the source opencode.json content differs from the snapshot
+ * currently stored in the session directory (or if no snapshot exists yet).
+ *
+ * Callers should use this to decide whether to invalidate the existing
+ * ACP session so the next message is served by a freshly spawned opencode
+ * acp child that loads the updated configuration.
+ */
+export function hasOpenCodeConfigChanged(sessionDir: string, projectDir?: string): boolean {
+  const sourceDir = projectDir || process.cwd()
+  const sourcePath = path.join(sourceDir, "opencode.json")
+  const targetPath = path.join(sessionDir, "opencode.json")
+
+  if (!fs.existsSync(sourcePath)) return false
+  if (!fs.existsSync(targetPath)) return true
+
+  const sourceHash = hashFile(sourcePath)
+  const targetHash = hashFile(targetPath)
+  return sourceHash !== null && targetHash !== null && sourceHash !== targetHash
 }
 
 /**


### PR DESCRIPTION
Previously the bridge copied `opencode.json` into each per-chat session directory only when the source mtime was strictly newer than the target's. This breaks for git checkouts, restores, and edits that preserve timestamps, leaving the cached snapshot and the running `opencode acp` child out of sync with the project's `opencode.json`.

Replace the mtime-based `copyIfNewer` helper with `copyIfChanged`, which compares SHA-256 of the file contents and refreshes when they differ (or when no snapshot exists yet). `copyOpenCodeConfig` now returns whether anything was refreshed so callers can react.

Also export `hasOpenCodeConfigChanged(sessionDir)` for callers that need to decide whether to invalidate an existing session before the next message is processed. The matching invalidation logic lives in a follow-up branch (#PR2).

Tests: `bun test tests/unit/session-utils.test.ts tests/unit/connector-base.test.ts` — 106 pass, 0 fail.