### PR TITLE
WIP: Strip <think> blocks from chat responses (closes #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Leaked `<think>` blocks in chat responses** - Reasoning models that
+  emit `<think>...</think>` inline in the regular message stream
+  (Qwen-style, DeepSeek R1, etc.) no longer leak the raw tags and
+  reasoning content into every connector. A new `stripThinkBlocks`
+  helper runs alongside the existing image, document, and path
+  sanitizers. Only well-formed blocks are removed; unclosed tags and
+  the dedicated `agent_thought_chunk` reasoning channel are left alone.
 - **Web tool trace line breaks** - Activity and trace messages now preserve
   newlines and safely wrap long lines in widget, embedded, and full-page modes.
 - **Web reconnect state** - Session confirmation no longer clears queued or

--- a/connectors/discord.ts
+++ b/connectors/discord.ts
@@ -31,6 +31,7 @@ import {
   shouldShowToolOutput,
   extractImagePaths,
   removeImageMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
 } from "../src"
 import { getConfig } from "../src/config"
@@ -333,7 +334,7 @@ class DiscordConnector extends BaseConnector<ChannelSession> {
       }
 
       // Clean response and send
-      const cleanResponse = sanitizeServerPaths(removeImageMarkers(responseBuffer))
+      const cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(responseBuffer)))
       if (cleanResponse) {
         session.outputChars += cleanResponse.length
         

--- a/connectors/matrix.ts
+++ b/connectors/matrix.ts
@@ -49,6 +49,7 @@ import {
   shouldShowToolOutput,
   extractImagePaths,
   removeImageMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
 } from "../src"
 
@@ -589,7 +590,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
       session.lastEventIds.set(context.replyThreadRootId, context.eventId)
 
       let attempt = await runAttempt(session)
-      let cleanResponse = sanitizeServerPaths(removeImageMarkers(attempt.responseBuffer))
+      let cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(attempt.responseBuffer)))
       let diagnostic = diagnoseEmptyResponse(attempt.acpResponse, attempt.responseBuffer, cleanResponse)
 
       if (diagnostic?.source === "bridge-capture-lost") {
@@ -599,7 +600,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
           `cleanChars=${diagnostic.cleanChars} chunks=${attempt.chunkCount} [${context.sessionId}]`,
         )
         attempt.responseBuffer = attempt.acpResponse
-        cleanResponse = sanitizeServerPaths(removeImageMarkers(attempt.responseBuffer))
+        cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(attempt.responseBuffer)))
         diagnostic = diagnoseEmptyResponse(attempt.acpResponse, attempt.responseBuffer, cleanResponse)
       }
 
@@ -624,7 +625,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
           session.inputChars += query.length
           session.lastEventIds.set(context.replyThreadRootId, context.eventId)
           attempt = await runAttempt(session)
-          cleanResponse = sanitizeServerPaths(removeImageMarkers(attempt.responseBuffer))
+          cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(attempt.responseBuffer)))
           diagnostic = diagnoseEmptyResponse(attempt.acpResponse, attempt.responseBuffer, cleanResponse)
 
           if (diagnostic?.source === "bridge-capture-lost") {
@@ -634,7 +635,7 @@ export class MatrixConnector extends BaseConnector<RoomSession> {
               `cleanChars=${diagnostic.cleanChars} chunks=${attempt.chunkCount} [${context.sessionId}]`,
             )
             attempt.responseBuffer = attempt.acpResponse
-            cleanResponse = sanitizeServerPaths(removeImageMarkers(attempt.responseBuffer))
+            cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(attempt.responseBuffer)))
             diagnostic = diagnoseEmptyResponse(attempt.acpResponse, attempt.responseBuffer, cleanResponse)
           }
 

--- a/connectors/mattermost.ts
+++ b/connectors/mattermost.ts
@@ -32,6 +32,7 @@ import {
   shouldShowToolOutput,
   extractImagePaths,
   removeImageMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
 } from "../src"
 
@@ -679,7 +680,7 @@ export class MattermostConnector extends BaseConnector<ChannelSession> {
       }
 
       // Send final response (never deduplicate against tool outputs)
-      const cleanResponse = sanitizeServerPaths(removeImageMarkers(responseBuffer))
+      const cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(responseBuffer)))
       if (cleanResponse) {
         session.outputChars += cleanResponse.length
         await this.sendReply(context, cleanResponse)

--- a/connectors/slack.ts
+++ b/connectors/slack.ts
@@ -33,6 +33,7 @@ import {
   shouldShowToolOutput,
   extractImagePaths,
   removeImageMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
 } from "../src"
 
@@ -554,7 +555,7 @@ export class SlackConnector extends BaseConnector<ChannelSession> {
       }
 
       // Clean response and send
-      const cleanResponse = sanitizeServerPaths(removeImageMarkers(responseBuffer))
+      const cleanResponse = sanitizeServerPaths(removeImageMarkers(stripThinkBlocks(responseBuffer)))
       if (cleanResponse) {
         session.outputChars += cleanResponse.length
         await this.sendReply(slackClient, context, cleanResponse)

--- a/connectors/telegram.ts
+++ b/connectors/telegram.ts
@@ -41,6 +41,7 @@ import {
   extractDocPaths,
   removeImageMarkers,
   removeDocMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
   getSessionDir,
   ensureSessionDir,
@@ -1340,7 +1341,7 @@ export class TelegramConnector extends BaseConnector<ChatSession> {
 
         // Final cleaned response
         const cleanResponse = sanitizeServerPaths(
-          removeDocMarkers(removeImageMarkers(responseBuffer))
+          removeDocMarkers(removeImageMarkers(stripThinkBlocks(responseBuffer)))
         )
         if (cleanResponse) {
           session.outputChars += cleanResponse.length

--- a/connectors/web.ts
+++ b/connectors/web.ts
@@ -42,6 +42,7 @@ import {
   sanitizeServerPaths,
   extractImagePaths,
   removeImageMarkers,
+  stripThinkBlocks,
   extractDocPaths,
   removeDocMarkers,
 } from "../src"
@@ -606,7 +607,7 @@ export class WebConnector extends BaseConnector<WebSession> {
     }
 
     const cleanAttempt = (attempt: Awaited<ReturnType<typeof runAttempt>>) =>
-      sanitizeServerPaths(removeDocMarkers(removeImageMarkers(attempt.buf)))
+      sanitizeServerPaths(removeDocMarkers(removeImageMarkers(stripThinkBlocks(attempt.buf))))
 
     const sessionLabel = (session: WebSession) =>
       session.client.currentSessionId?.slice(0, 8) || "unknown"

--- a/connectors/whatsapp.ts
+++ b/connectors/whatsapp.ts
@@ -38,6 +38,7 @@ import {
   extractDocPaths,
   removeImageMarkers,
   removeDocMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
 } from "../src"
 
@@ -542,7 +543,7 @@ class WhatsAppConnector extends BaseConnector<ChatSession> {
       }
 
       // Clean response and send
-      const cleanResponse = sanitizeServerPaths(removeDocMarkers(removeImageMarkers(responseBuffer)))
+      const cleanResponse = sanitizeServerPaths(removeDocMarkers(removeImageMarkers(stripThinkBlocks(responseBuffer))))
       if (cleanResponse) {
         session.outputChars += cleanResponse.length
         await this.sendMessage(chatId, cleanResponse)

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
   extractDocPaths,
   removeImageMarkers,
   removeDocMarkers,
+  stripThinkBlocks,
   sanitizeServerPaths,
   copyOpenCodeConfig,
   copyACPProfile,

--- a/src/session-utils.ts
+++ b/src/session-utils.ts
@@ -364,7 +364,7 @@ export function extractDocPaths(text: string): string[] {
 
 /**
  * Remove all document markers from text
- * 
+ *
  * @param text - Text containing document markers
  * @returns Text with document markers removed
  */
@@ -372,4 +372,37 @@ export function removeDocMarkers(text: string): string {
   return text
     .replace(/\[DOCLIBRARY_DOC\][^\[]+\[\/DOCLIBRARY_DOC\]/gi, "")
     .trim()
+}
+
+// =============================================================================
+// Think Block Utilities
+// =============================================================================
+
+/**
+ * Strip `<think>...</think>` blocks from model response text.
+ *
+ * Some reasoning models (Qwen-style, DeepSeek R1, etc.) emit a
+ * `<think>...</think>` block inline in the regular `agent_message_chunk`
+ * text stream rather than (or in addition to) using the dedicated
+ * `agent_thought_chunk` channel. Without this filter the raw tags and
+ * reasoning content leak into the chat on every connector.
+ *
+ * The match is intentionally conservative:
+ * - Only well-formed (closed) blocks are removed. An unclosed `<think>`
+ *   tag is left untouched to avoid eating legitimate text that happens
+ *   to contain the literal sequence (XML examples, code snippets,
+ *   documentation about reasoning formats, quoted transcripts, etc.).
+ * - Matching is case-insensitive to be lenient with model output.
+ * - Multiple blocks are all removed.
+ * - The surrounding text is left otherwise intact and trimmed.
+ *
+ * Note: this only filters inline `<think>` blocks. The dedicated
+ * `agent_thought_chunk` channel is handled separately by the ACP client
+ * and never reaches the connectors.
+ *
+ * @param text - Text that may contain `<think>...</think>` blocks
+ * @returns Text with well-formed think blocks removed
+ */
+export function stripThinkBlocks(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>/gi, "").trim()
 }

--- a/tests/unit/session-utils.test.ts
+++ b/tests/unit/session-utils.test.ts
@@ -15,6 +15,7 @@ import {
   estimateTokens,
   extractImagePaths,
   removeImageMarkers,
+  stripThinkBlocks,
   copyOpenCodeConfig,
   copyACPProfile,
 } from "../../src/session-utils"
@@ -426,5 +427,95 @@ describe("cleanupOldSessions", () => {
     expect(result).toBe(1)
     expect(fs.existsSync(oldSession)).toBe(false)
     expect(fs.existsSync(newSession)).toBe(true)
+  })
+})
+
+// =============================================================================
+// stripThinkBlocks
+// =============================================================================
+
+describe("stripThinkBlocks", () => {
+  test("removes a single think block at the start of the response", () => {
+    const text = "<think>Let me reason about this...</think>The answer is 42."
+    expect(stripThinkBlocks(text)).toBe("The answer is 42.")
+  })
+
+  test("removes a think block in the middle of the response", () => {
+    const text = "Hello <think>reasoning</think> world"
+    expect(stripThinkBlocks(text)).toBe("Hello  world")
+  })
+
+  test("removes a think block at the end of the response", () => {
+    const text = "The answer is 42.<think>now I will stop</think>"
+    expect(stripThinkBlocks(text)).toBe("The answer is 42.")
+  })
+
+  test("removes a think block spanning multiple lines", () => {
+    const text = "<think>line one\nline two\nline three</think>\nFinal answer."
+    expect(stripThinkBlocks(text)).toBe("Final answer.")
+  })
+
+  test("removes multiple think blocks", () => {
+    const text = "<think>first reasoning</think>Step 1.<think>second reasoning</think>Step 2."
+    expect(stripThinkBlocks(text)).toBe("Step 1.Step 2.")
+  })
+
+  test("is case-insensitive", () => {
+    const text = "<THINK>uppercase tags</THINK>kept"
+    expect(stripThinkBlocks(text)).toBe("kept")
+  })
+
+  test("matches mixed-case tags", () => {
+    const text = "<Think>Mixed</Think>kept"
+    expect(stripThinkBlocks(text)).toBe("kept")
+  })
+
+  test("returns original text when no think blocks", () => {
+    const text = "Just regular text without any think blocks."
+    expect(stripThinkBlocks(text)).toBe("Just regular text without any think blocks.")
+  })
+
+  test("leaves unclosed think tags untouched", () => {
+    // Conservative: an unclosed <think> tag could be legitimate text
+    // (e.g. XML example, code snippet). Do not eat the rest of the message.
+    const text = "Unclosed <think> begins here and never closes"
+    expect(stripThinkBlocks(text)).toBe("Unclosed <think> begins here and never closes")
+  })
+
+  test("leaves a <think> opening tag with no closing tag alone", () => {
+    const text = "<think>only opening\nthe rest is reasoning"
+    expect(stripThinkBlocks(text)).toBe("<think>only opening\nthe rest is reasoning")
+  })
+
+  test("handles empty string", () => {
+    expect(stripThinkBlocks("")).toBe("")
+  })
+
+  test("returns empty string when response is only a think block", () => {
+    const text = "<think>only reasoning, no answer</think>"
+    expect(stripThinkBlocks(text)).toBe("")
+  })
+
+  test("preserves surrounding whitespace inside the response", () => {
+    const text = "<think>reasoning</think>\n\nThe actual answer."
+    expect(stripThinkBlocks(text)).toBe("The actual answer.")
+  })
+
+  test("does not match nested closing tags greedily", () => {
+    // Non-greedy match should stop at the first </think>.
+    const text = "<think>a</think>middle<think>b</think>end"
+    expect(stripThinkBlocks(text)).toBe("middleend")
+  })
+
+  test("preserves think-like text that is not a real think block", () => {
+    // <think>ish (missing slash) is not a closing tag, so the block is
+    // treated as unclosed and left alone.
+    const text = "Use <think>ish> as a placeholder"
+    expect(stripThinkBlocks(text)).toBe("Use <think>ish> as a placeholder")
+  })
+
+  test("preserves user prompts that mention <think> in code examples", () => {
+    const text = 'Example: `<think>should be visible</think>` literal sequence'
+    expect(stripThinkBlocks(text)).toBe("Example: `` literal sequence")
   })
 })


### PR DESCRIPTION
**Status: WIP / draft — do not merge.**

Reasoning models that emit `<think>...</think>` inline in the regular
message stream (Qwen-style, DeepSeek R1, etc.) were leaking the raw
tags and reasoning content into every connector. This branch adds a
conservative `stripThinkBlocks` helper in `src/session-utils.ts` that
removes well-formed (closed) `<think>` blocks case-insensitively, and
applies it at the front of every connector's response cleaning
pipeline (matrix, slack, discord, mattermost, telegram, whatsapp, web).

### Known issue — still leaking in some cases

Initial testing shows the stripper works for inline blocks that arrive
entirely on the `agent_message_chunk` channel, but **occasionally an
orphan `</think>` tag still reaches the chat**. The current regex
(`/<think>[\s\S]*?<\/think>/gi`) requires both tags in the same string,
so it misses blocks split across the two ACP channels — most likely
when the model emits the opening `<think>` on `agent_thought_chunk`
(which the connectors drop into `updateHandler` rather than
`responseBuffer`) and the closing `</think>` plus the answer on
`agent_message_chunk`. With only the closing half in
`responseBuffer`, the helper has nothing to match and the orphan
`</think>` survives cleaning.

I am still debugging this. Likely next steps:

1. Add a one-shot debug log of the raw `responseBuffer` (and any
   `agent_thought_chunk` text captured separately) on the affected
   connector to confirm the channel-split hypothesis.
2. Either widen the regex to also strip orphan `</think>` (with a
   warning, dropping the conservative guarantee) **or** capture
   `agent_thought_chunk` text into the same buffer so the regex sees
   both halves.
3. Re-run and confirm no `<think>` / `</think>` survives on any
   connector before removing the WIP/draft flag.

Tracking issue: #73.